### PR TITLE
Feat(import-map): Added Host remoteEntry.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.9.0 - Added support for host remoteEntry.json
+- Added config for including a host remoteEntry.json.
+- [breaking] Changed `load()` to `loadRemoteModule()` to be consistent with native-federation-runtime.
+- moved config object to root lib folder. 
+
 ## 0.8.4 - Moved dependencies to devDependencies
 - Moved SystemJS and eslint-plugin-prettier to devDependencies.
 
@@ -13,8 +18,7 @@
 
 ## 0.8.1 - Shared version compatibility check
 - Added version resolving compatibility check (error if strict, warning otherwise).
-- If an dependency incompatibility error occurs, the remote module will not be loaded/initialized. 
-
+- If an dependency incompatibility error occurs, the remote module will not be loaded/initialized. . i
 ## 0.8.0 - Improved dependency (external) sharing
 - Support for 'singleton' dependencies.
 - 'vite' dependencies are now optional based on `buildType` in the config (prefixed with `/@id/`).

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,4 @@ export { initFederation } from './lib/init-federation';
 
 export * from './lib/handlers';
 export * from './lib/steps';
-export * from './lib/utils';
+export * from './lib/config';

--- a/src/lib/config/config.contract.ts
+++ b/src/lib/config/config.contract.ts
@@ -1,5 +1,5 @@
-import type { LogHandler, LogType } from "../../handlers/logging/log.contract"
-import type { NfCache, StorageEntryCreator } from "../../handlers/storage/storage.contract"
+import type { LogHandler, LogType } from "../handlers/logging/log.contract"
+import type { NfCache, StorageEntryCreator } from "../handlers/storage/storage.contract"
 
 
 type StorageConfig<TCache extends NfCache = NfCache> = {

--- a/src/lib/config/config.ts
+++ b/src/lib/config/config.ts
@@ -1,7 +1,7 @@
 import type { Config } from "./config.contract"
-import { noopLogger } from "../../handlers/logging/noop.logger"
-import { globalThisStorageEntry } from "../../handlers/storage/global-this-storage"
-import { createCache, type NfCache } from "../../handlers/storage/storage.contract"
+import { noopLogger } from "../handlers/logging/noop.logger"
+import { globalThisStorageEntry } from "../handlers/storage/global-this-storage"
+import { createCache, type NfCache } from "../handlers/storage/storage.contract"
 
 const defaultConfig = <TCache extends NfCache>(o: Partial<Config<TCache>>): Config<TCache> => {
     return {

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -1,0 +1,2 @@
+export { Config } from './config.contract';
+export { defaultConfig } from './config';

--- a/src/lib/handlers/externals/externals.handler.spec.ts
+++ b/src/lib/handlers/externals/externals.handler.spec.ts
@@ -38,11 +38,6 @@ describe('externalsHandler', () => {
         versionHandler = mockVersionHandler();
         logHandler = mockLogHandler();
         externalsHandler = externalsHandlerFactory(
-            {
-                builderType: "default",
-                loadModuleFn: jest.fn(),
-                importMapType: "importmap"
-            },
             storageHandler,
             logHandler,
             versionHandler

--- a/src/lib/handlers/externals/externals.handler.ts
+++ b/src/lib/handlers/externals/externals.handler.ts
@@ -1,6 +1,5 @@
 import type { ExternalsHandler, SharedInfo } from "./externals.contract";
 import { NFError } from "../../native-federation.error";
-import type { ModuleLoaderConfig } from "../../utils/config/config.contract";
 import * as _path from "../../utils/path";
 import type { LogHandler } from "../logging";
 import type { NfCache, StorageHandler } from "../storage/storage.contract";
@@ -14,15 +13,12 @@ import type { Version, VersionHandler } from "../version/version.contract";
  * @returns 
  */
 const externalsHandlerFactory = (
-    {builderType}: ModuleLoaderConfig,
     storageHandler: StorageHandler<NfCache>,
     logHandler: LogHandler,
     versionHandler: VersionHandler,
 
 ): ExternalsHandler => {
 
-    const filterByBuilderType = (dep: SharedInfo) => 
-        (builderType === 'vite') === dep.packageName.startsWith('/@id/');
 
     const appendToDependencyScope = (scopeUrl: string) => (external: SharedInfo) => (externals: NfCache["externals"]) => {
         const scope = (external.singleton) ? "global" : scopeUrl;
@@ -71,7 +67,6 @@ const externalsHandlerFactory = (
         const globalExternals = storageHandler.fetch('externals')["global"];
 
         const sharedExternals = externals
-            .filter(filterByBuilderType)
             .filter(e => e.singleton && globalExternals[e.packageName]);
 
         for (const newExternal of sharedExternals) {
@@ -102,7 +97,6 @@ const externalsHandlerFactory = (
         clearDependencyScope(scopeUrl);
 
         externals
-            .filter(filterByBuilderType)
             .map(appendToDependencyScope(scopeUrl))
             .forEach(updateFn => storageHandler.update("externals", updateFn));
 

--- a/src/lib/handlers/handlers.resolver.ts
+++ b/src/lib/handlers/handlers.resolver.ts
@@ -1,4 +1,4 @@
-import type { Config } from "../utils";
+import type { Config } from "../config";
 import { externalsHandlerFactory } from "./externals/externals.handler";
 import type { Handlers } from "./handlers.contract";
 import { importMapHandlerFactory } from "./import-map/import-map.handler";

--- a/src/lib/handlers/handlers.resolver.ts
+++ b/src/lib/handlers/handlers.resolver.ts
@@ -19,7 +19,7 @@ const resolveHandlers = <TCache extends NfCache>(
     // Core
     const versionHandler = versionHandlerFactory();
     const externalsHandler = externalsHandlerFactory(storageHandler, logHandler, versionHandler);
-    const remoteInfoHandler = remoteInfoHandlerFactory(storageHandler);
+    const remoteInfoHandler = remoteInfoHandlerFactory(config, storageHandler);
     const remoteModuleHandler = remoteModuleHandlerFactory(config, storageHandler);
 
     const importMapHandler = importMapHandlerFactory(config, externalsHandler, remoteInfoHandler);

--- a/src/lib/handlers/handlers.resolver.ts
+++ b/src/lib/handlers/handlers.resolver.ts
@@ -18,7 +18,7 @@ const resolveHandlers = <TCache extends NfCache>(
 
     // Core
     const versionHandler = versionHandlerFactory();
-    const externalsHandler = externalsHandlerFactory(config, storageHandler, logHandler, versionHandler);
+    const externalsHandler = externalsHandlerFactory(storageHandler, logHandler, versionHandler);
     const remoteInfoHandler = remoteInfoHandlerFactory(storageHandler);
     const remoteModuleHandler = remoteModuleHandlerFactory(config, storageHandler);
 

--- a/src/lib/handlers/import-map/import-map-handler.spec.ts
+++ b/src/lib/handlers/import-map/import-map-handler.spec.ts
@@ -15,7 +15,6 @@ describe('importMapHandler', () => {
         externalsHandler = mockExternalsHandler();
         importMapHandler = importMapHandlerFactory(
             {
-                builderType: "default",
                 loadModuleFn: jest.fn(),
                 importMapType: "importmap"
             },

--- a/src/lib/handlers/import-map/import-map.handler.ts
+++ b/src/lib/handlers/import-map/import-map.handler.ts
@@ -1,5 +1,5 @@
 import type { ImportMap, ImportMapHandler, Imports, Scopes } from "./import-map.contract";
-import type { ModuleLoaderConfig } from "../../utils/config/config.contract";
+import type { ModuleLoaderConfig } from "../../config/config.contract";
 import * as _path from "../../utils/path";
 import type { ExternalsHandler } from "../externals/externals.contract";
 import type { RemoteInfo, RemoteInfoHandler, RemoteName } from "../remote-info";

--- a/src/lib/handlers/logging/log.handler.ts
+++ b/src/lib/handlers/logging/log.handler.ts
@@ -1,5 +1,5 @@
 import { type LogHandler, type LogType, LogLevel } from "./log.contract";
-import type { LoggingConfig } from "../../utils/config/config.contract";
+import type { LoggingConfig } from "../../config/config.contract";
 
 const logHandlerFactory = ({logger, logLevel}: LoggingConfig): LogHandler => {
   const logTypes = Object.keys(LogLevel)

--- a/src/lib/handlers/remote-info/remote-info.contract.ts
+++ b/src/lib/handlers/remote-info/remote-info.contract.ts
@@ -15,6 +15,7 @@ type RemoteInfo = {
 type RemoteInfoHandler = {
     toStorage: (remote: {name: string; exposes: ExposesInfo[]}, baseUrl: string) => RemoteInfo,
     inStorage: (remoteName: string) => boolean,
+    getHostRemoteEntryUrl: () => string|undefined,
     fromStorage: (remoteName: string) => RemoteInfo,
     fetchRemoteEntry: (remoteEntryUrl: string) => Promise<FederationInfo>,
     toScope: (remoteEntry: RemoteEntry) => string

--- a/src/lib/handlers/remote-info/remote-info.handler.spec.ts
+++ b/src/lib/handlers/remote-info/remote-info.handler.spec.ts
@@ -4,7 +4,7 @@ import { mockStorageHandler } from './../../../mock/handlers.mock';
 import { remoteInfoHandlerFactory } from './remote-info.handler';
 import { ExposesInfo, SharedInfo } from "@softarc/native-federation-runtime";
 import { NFError } from "../../native-federation.error";
-import { RemoteEntryConfig } from '../../utils/config/config.contract';
+import { RemoteEntryConfig } from '../../config/config.contract';
 
 describe('remoteInfoHandler', () => {
     let storageHandler: StorageHandler<NfCache>;

--- a/src/lib/handlers/remote-info/remote-info.handler.spec.ts
+++ b/src/lib/handlers/remote-info/remote-info.handler.spec.ts
@@ -4,6 +4,7 @@ import { mockStorageHandler } from './../../../mock/handlers.mock';
 import { remoteInfoHandlerFactory } from './remote-info.handler';
 import { ExposesInfo, SharedInfo } from "@softarc/native-federation-runtime";
 import { NFError } from "../../native-federation.error";
+import { RemoteEntryConfig } from '../../utils/config/config.contract';
 
 describe('remoteInfoHandler', () => {
     let storageHandler: StorageHandler<NfCache>;
@@ -35,9 +36,11 @@ describe('remoteInfoHandler', () => {
                 exposes: [{key: './comp', outFileName: 'comp.js'}]
             }))
 
+
     beforeEach(() => {
         storageHandler = mockStorageHandler();
-        remoteInfoHandler = remoteInfoHandlerFactory(storageHandler);
+        const mockConfig: RemoteEntryConfig = {hostRemoteEntry: false};
+        remoteInfoHandler = remoteInfoHandlerFactory(mockConfig, storageHandler);
     });
 
     describe('toStorage', () => {
@@ -162,6 +165,30 @@ describe('remoteInfoHandler', () => {
             expect(actual()).rejects.toThrow(`Module not registered, provide a valid remoteEntryUrl.`);
         });
     });
+
+    describe('getHostRemoteEntryUrl', () => {
+        let mockConfig: RemoteEntryConfig = {hostRemoteEntry: false};
+
+        it('should return undefined if the config has a host remoteEntry.json disabled', () => {
+            mockConfig.hostRemoteEntry = false;
+            remoteInfoHandler = remoteInfoHandlerFactory(mockConfig, storageHandler);
+
+            expect(remoteInfoHandler.getHostRemoteEntryUrl()).toBeUndefined();
+        });
+
+        it('should return the host remoteEntry url if the config has a host remoteEntry.json enabled', () => {
+            mockConfig.hostRemoteEntry = {url: "./custom/remoteEntry.json"};
+            remoteInfoHandler = remoteInfoHandlerFactory(mockConfig, storageHandler);
+
+            expect(remoteInfoHandler.getHostRemoteEntryUrl()).toBe("./custom/remoteEntry.json");
+        });
+
+        it('should return the host remoteEntry url with cacheTag if', () => {
+            mockConfig.hostRemoteEntry = {url: "./custom/remoteEntry.json", cacheTag: "123abc"};
+            remoteInfoHandler = remoteInfoHandlerFactory(mockConfig, storageHandler);
+            expect(remoteInfoHandler.getHostRemoteEntryUrl()).toBe("./custom/remoteEntry.json?t=123abc");
+        });
+    })
 
     describe('fromStorage', () => {
         let cache: { remotes: Record<string, RemoteInfo> }

--- a/src/lib/handlers/remote-info/remote-info.handler.spec.ts
+++ b/src/lib/handlers/remote-info/remote-info.handler.spec.ts
@@ -141,7 +141,26 @@ describe('remoteInfoHandler', () => {
             const actual = await remoteInfoHandler.fetchRemoteEntry("http://localhost:3001/remoteEntry.json");
         
             expect(actual).toEqual(expected);
-        });    
+        }); 
+
+        it('Should initialize missing properties', async () => {
+
+            const expected = { shared: [], exposes: [] };
+
+            (global.fetch as any) = jest.fn(() =>
+                Promise.resolve({
+                    status: 200,
+                    ok: true,
+                    json: () => {
+                        return Promise.resolve({})
+                    }}
+                )
+            );
+
+            const actual = await remoteInfoHandler.fetchRemoteEntry("http://localhost:3001/remoteEntry.json");
+        
+            expect(actual).toEqual(expected);
+        });
 
         it('Should throw error if fetch failed', async () => {
             (global.fetch as any) = jest.fn(() =>

--- a/src/lib/handlers/remote-info/remote-info.handler.ts
+++ b/src/lib/handlers/remote-info/remote-info.handler.ts
@@ -2,9 +2,11 @@ import type { ExposesInfo, FederationInfo, RemoteEntry, RemoteInfo, RemoteInfoHa
 import { NFError } from "../../native-federation.error";
 import * as _path from "../../utils/path";
 import type { NfCache, StorageHandler } from "../storage/storage.contract";
+import type { RemoteEntryConfig } from "../../utils/config/config.contract";
 
 const remoteInfoHandlerFactory = (
-    storageHandler: StorageHandler<NfCache>, 
+    { hostRemoteEntry }: RemoteEntryConfig,
+    storageHandler: StorageHandler<NfCache> 
 ): RemoteInfoHandler => {
 
     const fetchRemoteEntryJson = async (entryUrl: RemoteEntry)
@@ -26,6 +28,16 @@ const remoteInfoHandlerFactory = (
 
             return fetchRemoteEntryJson(remoteEntryUrl);
         }
+
+
+    function getHostRemoteEntryUrl(): string|undefined {
+        if(!hostRemoteEntry) return undefined;
+
+        let url = hostRemoteEntry?.url ?? "./remoteEntry.json";
+        if(!!hostRemoteEntry?.cacheTag) url += `?t=${hostRemoteEntry.cacheTag}`;
+
+        return url;
+    } 
 
     function toScope(baseUrl: string): string {
         if (baseUrl === "global") return baseUrl;
@@ -63,7 +75,7 @@ const remoteInfoHandlerFactory = (
         return remoteInfo;
     }
 
-    return {toStorage, inStorage, fromStorage, fetchRemoteEntry, toScope};
+    return {toStorage, getHostRemoteEntryUrl, inStorage, fromStorage, fetchRemoteEntry, toScope};
 }
 
 export {remoteInfoHandlerFactory, RemoteInfoHandler};

--- a/src/lib/handlers/remote-info/remote-info.handler.ts
+++ b/src/lib/handlers/remote-info/remote-info.handler.ts
@@ -14,8 +14,14 @@ const remoteInfoHandlerFactory = (
             return fetch(entryUrl)
                 .then(r => {
                     if (!r.ok) return Promise.reject(new NFError(`${r.status} - ${r.statusText}`));
-                    return r.json() as unknown as FederationInfo;
+                    return r.json() as Promise<FederationInfo>;
                 })
+                .then(federationInfo => {
+                    if(!federationInfo.exposes) federationInfo.exposes = [];
+                    if(!federationInfo.shared) federationInfo.shared = [];
+                    return federationInfo;
+                })
+
                 .catch(e => {
                     return Promise.reject(new NFError(`Fetching remote from '${entryUrl}' failed: ${e.message}`));
                 })

--- a/src/lib/handlers/remote-info/remote-info.handler.ts
+++ b/src/lib/handlers/remote-info/remote-info.handler.ts
@@ -7,7 +7,7 @@ const remoteInfoHandlerFactory = (
     storageHandler: StorageHandler<NfCache>, 
 ): RemoteInfoHandler => {
 
-    const fetchRemoteEntryJson = (entryUrl: RemoteEntry)
+    const fetchRemoteEntryJson = async (entryUrl: RemoteEntry)
         : Promise<FederationInfo> => {
             return fetch(entryUrl)
                 .then(r => {

--- a/src/lib/handlers/remote-info/remote-info.handler.ts
+++ b/src/lib/handlers/remote-info/remote-info.handler.ts
@@ -2,7 +2,7 @@ import type { ExposesInfo, FederationInfo, RemoteEntry, RemoteInfo, RemoteInfoHa
 import { NFError } from "../../native-federation.error";
 import * as _path from "../../utils/path";
 import type { NfCache, StorageHandler } from "../storage/storage.contract";
-import type { RemoteEntryConfig } from "../../utils/config/config.contract";
+import type { RemoteEntryConfig } from "../../config/config.contract";
 
 const remoteInfoHandlerFactory = (
     { hostRemoteEntry }: RemoteEntryConfig,

--- a/src/lib/handlers/remote-module/remote-module.handler.spec.ts
+++ b/src/lib/handlers/remote-module/remote-module.handler.spec.ts
@@ -13,7 +13,6 @@ describe('remoteInfoHandler', () => {
         storageHandler = mockStorageHandler();
         remoteModuleHandler = remoteModuleHandlerFactory(
             {
-                builderType: "default",
                 loadModuleFn: jest.fn(),
                 importMapType: "importmap"
             },

--- a/src/lib/handlers/remote-module/remote-module.handler.ts
+++ b/src/lib/handlers/remote-module/remote-module.handler.ts
@@ -1,6 +1,6 @@
 import type { RemoteModule, RemoteModuleHandler } from "./remote-module.contract";
 import { NFError } from "../../native-federation.error";
-import type { ModuleLoaderConfig } from "../../utils/config/config.contract";
+import type { ModuleLoaderConfig } from "../../config/config.contract";
 import type { NfCache, StorageHandler } from "../storage";
 
 const remoteModuleHandlerFactory = (

--- a/src/lib/handlers/storage/storage.handler.ts
+++ b/src/lib/handlers/storage/storage.handler.ts
@@ -1,5 +1,5 @@
 import type { StorageHandler, StorageEntry, NfCache, StorageOf } from "./storage.contract";
-import type { StorageConfig } from "../../utils/config/config.contract";
+import type { StorageConfig } from "../../config/config.contract";
 
 const storageHandlerFactory = <TCache extends NfCache>(
     {cache, toStorageEntry}: StorageConfig<TCache>

--- a/src/lib/init-federation.ts
+++ b/src/lib/init-federation.ts
@@ -1,7 +1,7 @@
 import type { StepFactories } from "./steps/steps.contract";
 import { resolver } from "./steps/steps.resolver";
-import { defaultConfig } from "./utils/config/config";
-import type { Config } from "./utils/config/config.contract";
+import { defaultConfig } from "./config/config";
+import type { Config } from "./config/config.contract";
 
 const initFederation = (
     remotesOrManifestUrl: string | Record<string, string> = {},

--- a/src/lib/steps/2-fetch-remote-entries.ts
+++ b/src/lib/steps/2-fetch-remote-entries.ts
@@ -24,7 +24,7 @@ const fetchRemoteEntries = (
             const url = remoteInfoHandler.getHostRemoteEntryUrl();
             if(!url) return remotes;
 
-            return [...remotes, ["__NF-HOST__", url]];
+            return [["__NF-HOST__", url], ...remotes];
         } 
 
         const fetchRemoteEntry = ([remoteName, remoteEntry]: [RemoteName,RemoteEntry]): Promise<RemoteInfo|false> => {

--- a/src/lib/steps/4-expose-module-loader.ts
+++ b/src/lib/steps/4-expose-module-loader.ts
@@ -5,14 +5,14 @@ import * as _path from "../utils/path";
 type LoadRemoteModule = (remoteName: string, exposedModule: string) => Promise<unknown>
 
 type ExposeModuleLoader = (manifest: Record<RemoteName, RemoteEntry>) => Promise<{
-    load: LoadRemoteModule, 
+    loadRemoteModule: LoadRemoteModule, 
     manifest: Record<RemoteName, RemoteEntry>
 }>
 
 const exposeModuleLoader = (
     { logHandler, remoteModuleHandler}: Handlers
 ): ExposeModuleLoader => {
-    function load(
+    function loadRemoteModule(
         remoteName: string, exposedModule: string
     ): Promise<unknown> {
         try{
@@ -30,7 +30,7 @@ const exposeModuleLoader = (
  
     }
 
-    return (manifest: Record<RemoteName, RemoteEntry>) => Promise.resolve({ manifest, load });
+    return (manifest: Record<RemoteName, RemoteEntry>) => Promise.resolve({ manifest, loadRemoteModule });
 }
 
 export {ExposeModuleLoader, exposeModuleLoader, LoadRemoteModule}

--- a/src/lib/steps/steps.resolver.ts
+++ b/src/lib/steps/steps.resolver.ts
@@ -5,7 +5,7 @@ import { exposeModuleLoader } from "./4-expose-module-loader";
 import type { StepFactories } from "./steps.contract";
 import { resolveHandlers } from "../handlers/handlers.resolver";
 import type { NfCache } from "../handlers/storage/storage.contract";
-import type { Config } from "../utils/config/config.contract";
+import type { Config } from "../config/config.contract";
 
 const resolver = <TCache extends NfCache>(
     config: Config<TCache>,

--- a/src/lib/utils/config/config.contract.ts
+++ b/src/lib/utils/config/config.contract.ts
@@ -12,11 +12,18 @@ type LoggingConfig = {
     logLevel: LogType,
 }
 
+type RemoteEntryConfig = {
+    hostRemoteEntry: false|{
+        url: string,
+        cacheTag?: string
+    }
+}
+
 type ModuleLoaderConfig = {
     importMapType: string,
     loadModuleFn: (url: string) => unknown
 }
 
-type Config<TCache extends NfCache = NfCache> = StorageConfig<TCache> & LoggingConfig & ModuleLoaderConfig
+type Config<TCache extends NfCache = NfCache> = StorageConfig<TCache> & RemoteEntryConfig & LoggingConfig & ModuleLoaderConfig
 
-export { Config, StorageConfig, LoggingConfig, ModuleLoaderConfig }
+export { Config, StorageConfig, RemoteEntryConfig, LoggingConfig, ModuleLoaderConfig }

--- a/src/lib/utils/config/config.contract.ts
+++ b/src/lib/utils/config/config.contract.ts
@@ -12,14 +12,11 @@ type LoggingConfig = {
     logLevel: LogType,
 }
 
-type BuilderType = 'vite'|'default';
-
 type ModuleLoaderConfig = {
-    builderType: BuilderType,
     importMapType: string,
     loadModuleFn: (url: string) => unknown
 }
 
 type Config<TCache extends NfCache = NfCache> = StorageConfig<TCache> & LoggingConfig & ModuleLoaderConfig
 
-export { Config, StorageConfig, LoggingConfig, BuilderType, ModuleLoaderConfig }
+export { Config, StorageConfig, LoggingConfig, ModuleLoaderConfig }

--- a/src/lib/utils/config/config.ts
+++ b/src/lib/utils/config/config.ts
@@ -10,7 +10,7 @@ const defaultConfig = <TCache extends NfCache>(o: Partial<Config<TCache>>): Conf
         
         logger: o.logger ?? noopLogger,
         logLevel: o.logLevel ?? "error",
-
+        hostRemoteEntry: o.hostRemoteEntry ?? false,
         importMapType: o.importMapType ?? "importmap",
         loadModuleFn: o.loadModuleFn ?? (url => import(url))
     }

--- a/src/lib/utils/config/config.ts
+++ b/src/lib/utils/config/config.ts
@@ -11,7 +11,6 @@ const defaultConfig = <TCache extends NfCache>(o: Partial<Config<TCache>>): Conf
         logger: o.logger ?? noopLogger,
         logLevel: o.logLevel ?? "error",
 
-        builderType: o.builderType ?? "default",
         importMapType: o.importMapType ?? "importmap",
         loadModuleFn: o.loadModuleFn ?? (url => import(url))
     }

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,3 +1,0 @@
-
-export { Config } from './config/config.contract';
-export { defaultConfig } from './config/config';

--- a/src/mock/handlers.mock.ts
+++ b/src/mock/handlers.mock.ts
@@ -27,6 +27,7 @@ const mockRemoteInfoHandler = (): RemoteInfoHandler => ({
     toStorage: jest.fn(),
     fromStorage: jest.fn(),
     fetchRemoteEntry: jest.fn(),
+    getHostRemoteEntryUrl: jest.fn(),
     inStorage: jest.fn(),
     toScope: jest.fn()
 });

--- a/src/plugins/module-loader/use-import-shim.ts
+++ b/src/plugins/module-loader/use-import-shim.ts
@@ -1,4 +1,4 @@
-import type { ModuleLoaderConfig } from "../../lib/utils/config/config.contract"
+import type { ModuleLoaderConfig } from "../../lib/config/config.contract"
 
 declare function importShim<T>(url: string): T;
 

--- a/src/plugins/module-loader/use-import-shim.ts
+++ b/src/plugins/module-loader/use-import-shim.ts
@@ -1,9 +1,8 @@
-import type { BuilderType, ModuleLoaderConfig } from "../../lib/utils/config/config.contract"
+import type { ModuleLoaderConfig } from "../../lib/utils/config/config.contract"
 
 declare function importShim<T>(url: string): T;
 
-const useImportMapShim = (builderType: BuilderType = 'default'): ModuleLoaderConfig => ({
-    builderType,
+const useImportMapShim = (): ModuleLoaderConfig => ({
     importMapType: "importmap",
     loadModuleFn: (url) => importShim(url)
 })

--- a/src/plugins/module-loader/use-systemjs.ts
+++ b/src/plugins/module-loader/use-systemjs.ts
@@ -1,4 +1,4 @@
-import type { BuilderType, ModuleLoaderConfig } from "../../lib/utils/config/config.contract"
+import type { ModuleLoaderConfig } from "../../lib/utils/config/config.contract"
 
 declare global {
     interface Window {
@@ -8,8 +8,7 @@ declare global {
     }
   }
 
-const useSystemJS = (builderType: BuilderType = 'default'): ModuleLoaderConfig => ({
-    builderType,
+const useSystemJS = (): ModuleLoaderConfig => ({
     importMapType: "systemjs-importmap",
     loadModuleFn: (url) => window.System.import(url)
 })

--- a/src/plugins/module-loader/use-systemjs.ts
+++ b/src/plugins/module-loader/use-systemjs.ts
@@ -1,4 +1,4 @@
-import type { ModuleLoaderConfig } from "../../lib/utils/config/config.contract"
+import type { ModuleLoaderConfig } from "../../lib/config/config.contract"
 
 declare global {
     interface Window {

--- a/src/plugins/quickstart/index.ts
+++ b/src/plugins/quickstart/index.ts
@@ -21,7 +21,7 @@ import { useImportMapShim } from '../module-loader';
     await initFederation(JSON.parse(jsonScript.textContent), {
         logger: consoleLogger, 
         logLevel: "debug", 
-        ...useImportMapShim("default"),
+        ...useImportMapShim(),
         importMapType: 'importmap'
     }).then(({load}) => {
         (window as any).loadRemoteModule = load

--- a/src/plugins/quickstart/index.ts
+++ b/src/plugins/quickstart/index.ts
@@ -23,8 +23,8 @@ import { useImportMapShim } from '../module-loader';
         logLevel: "debug", 
         ...useImportMapShim(),
         importMapType: 'importmap'
-    }).then(({load}) => {
-        (window as any).loadRemoteModule = load
-        window.dispatchEvent(new CustomEvent("mfe-loader-available", {detail: {load}}));
+    }).then(({loadRemoteModule}) => {
+        (window as any).loadRemoteModule = loadRemoteModule
+        window.dispatchEvent(new CustomEvent("mfe-loader-available", {detail: {loadRemoteModule}}));
     });
 })();


### PR DESCRIPTION
## 0.9.0 - Added support for host remoteEntry.json
- Added config for including a host remoteEntry.json.
- [breaking] Changed `load()` to `loadRemoteModule()` to be consistent with native-federation-runtime.
- moved config object to root lib folder. 
