### PR TITLE
fix(nf-host) Fixed importmap error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.9.2 - Fixed import bug
+- Changed `-` to `_` in namespaces.
+- Fixed bug in which `__NF_HOST__` remote was not being stored in cache leading to an error thrown during ImportMap buildup. 
+- The host remoteEntry.json is stored as `__NF_HOST__` entry now. The `name` attribute in the host remoteEntry.json will be changed to `__NF_HOST__` 
+
+## 0.9.1 - Simplified usage for hosts [BROKEN]
+- Added option to set host remoteEntry.json as manifest.
+- Added shimMode option to useImportMapShim plugin. 
+- Added namespaces for reused variables like the 'remoteEntry.json' filename and the '__NATIVE-FEDERATION__' storage entry.
+
 ## 0.9.0 - Added support for host remoteEntry.json
 - Added config for including a host remoteEntry.json.
 - [breaking] Changed `load()` to `loadRemoteModule()` to be consistent with native-federation-runtime.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.9.0",
+  "version": "0.9.2",
   "name": "vanilla-native-federation",
   "author": "aukevanoost",
   "keywords": [

--- a/src/lib/config/namespace.contract.ts
+++ b/src/lib/config/namespace.contract.ts
@@ -1,7 +1,7 @@
 
-const NF_HOST_REMOTE_ENTRY = "__NF-HOST__";
+const NF_HOST_REMOTE_ENTRY = "__NF_HOST__";
 
-const NF_STORAGE_ENTRY = "__NATIVE-FEDERATION__";
+const NF_STORAGE_ENTRY = "__NATIVE_FEDERATION__";
 
 const NF_REMOTE_ENTRY_FILENAME = "remoteEntry.json";
 

--- a/src/lib/steps/1-fetch-manifest.ts
+++ b/src/lib/steps/1-fetch-manifest.ts
@@ -5,19 +5,34 @@ import {NF_HOST_REMOTE_ENTRY, NF_REMOTE_ENTRY_FILENAME} from "../config/namespac
 type FetchManifest = (remotesOrManifestUrl: string | Record<RemoteName, RemoteEntry>) => Promise<Record<RemoteName, RemoteEntry>>
 
 const fetchManifest = (
-    {}: Handlers
+    {logHandler, remoteInfoHandler}: Handlers
 ): FetchManifest => 
-    (remotesOrManifestUrl: string | Record<RemoteName, RemoteEntry> = {}) => {
-    
+    async (remotesOrManifestUrl: string | Record<RemoteName, RemoteEntry> = {}) => {
+   
+        const appendHostRemoteEntry = (manifest: Record<RemoteName, RemoteEntry>, hostRemoteEntryUrl: string)
+            : Record<RemoteName, RemoteEntry> => ({
+                [NF_HOST_REMOTE_ENTRY]: hostRemoteEntryUrl, 
+                ...manifest 
+            })
+        
+        const appendHostRemoteEntryIfInConfig = (manifest: Record<RemoteName, RemoteEntry>): Record<RemoteName, RemoteEntry> => {
+            const hostRemoteEntryUrl = remoteInfoHandler.getHostRemoteEntryUrl();
+            if(!!hostRemoteEntryUrl) {
+                logHandler.debug(`Appended host '${hostRemoteEntryUrl}' from config.`)
+                return appendHostRemoteEntry(manifest, hostRemoteEntryUrl);
+            }
+            return manifest;
+        };
+
         const fetchManifest = (): Promise<Record<RemoteName, RemoteEntry>> => {
             return (typeof remotesOrManifestUrl === 'string')
                 ? remotesOrManifestUrl.endsWith(NF_REMOTE_ENTRY_FILENAME)
-                    ? Promise.resolve({[NF_HOST_REMOTE_ENTRY]: remotesOrManifestUrl})
+                    ? Promise.resolve(appendHostRemoteEntry({}, remotesOrManifestUrl))
                     : fetch(remotesOrManifestUrl).then(r => r.json())
                 : Promise.resolve(remotesOrManifestUrl)
         }
 
-        return fetchManifest();
+        return fetchManifest().then(appendHostRemoteEntryIfInConfig);
     }
 
 export {FetchManifest, fetchManifest}


### PR DESCRIPTION
## 0.9.2 - Fixed import bug
- Changed `-` to `_` in namespaces.
- Fixed bug in which `__NF_HOST__` remote was not being stored in cache leading to an error thrown during ImportMap buildup. 
- The host remoteEntry.json is stored as `__NF_HOST__` entry now. The `name` attribute in the host remoteEntry.json will be changed to `__NF_HOST__` 
