### PR TITLE
[v0.11.1] - Bugfix in initialization phase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 node_modules
 dist
 coverage
-.DS_Store
-*/.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.1 - Bugfix: Init failed if one remoteEntry was skipped in step 1 (metadata verification step)
+- [fix] Init will now only log an error and a warning if a module could not be initialized instead of throwing an error during init.
+- [test] Cleaned the test in externals handler.
+
 ## 0.11.0 - Integrated more robust Semver library
 - Integraded Semver library for version management.
 - Exposed Step interfaces for easy overrides.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.11.0",
+  "version": "0.11.1",
   "name": "vanilla-native-federation",
   "author": "aukevanoost",
   "keywords": [

--- a/src/lib/handlers/externals/externals.handler.spec.ts
+++ b/src/lib/handlers/externals/externals.handler.spec.ts
@@ -404,7 +404,7 @@ describe('externalsHandler', () => {
             ]);
         });
 
-        it('to send an error if new singleton is outside of range', () => {
+        it('to send an error if new (strict) singleton is outside of range', () => {
             (storageHandler.fetch as jest.Mock) = jest.fn((): {global: Record<string, Version>} => ({
                 global: {
                     "rxjs": {version: "7.6.2", strictRequiredVersion: "^7.6.0", url: "http://localhost:3001/NEW-PACKAGE.js" }
@@ -414,7 +414,7 @@ describe('externalsHandler', () => {
 
             const actual = () => externalsHandler.checkForIncompatibleSingletons(MOCK_SHARED_INFO({singleton: true, strictVersion: false}));
 
-            expect(actual).toThrow("[rxjs] Shared version '7.8.1' is not compatible to version range '^7.6.0'");
+            expect(actual).toThrow("[rxjs] Shared (strict) version '7.8.1' is not compatible to version range '^7.6.0'");
         });
 
         it('to send the current stored version is outside of new singleton range', () => {

--- a/src/lib/handlers/externals/externals.handler.spec.ts
+++ b/src/lib/handlers/externals/externals.handler.spec.ts
@@ -111,11 +111,38 @@ describe('externalsHandler', () => {
             versionHandler.getSmallestVersionRange = jest.fn((): string => "^7.8.0");
         })
 
+        it('should remove previously stored dependencies from scope', () => {
+            const SCOPE = MOCK_SCOPE(); 
+            const sharedInfo = MOCK_SHARED_INFO({singleton: true, strictVersion: false});
+
+            const cacheBefore = {
+                global: {},
+                [SCOPE]: {
+                    "rxjs": {version: "7.8.1", requiredVersion: "^7.8.0", url: "http://localhost:3001/rxjs.js" }
+                }
+            } as CacheGlobalExternals & CacheScopedExternals
+
+            const expected = {
+                global: {},
+                [SCOPE]: {}
+            }
+
+            externalsHandler.toStorage(sharedInfo, SCOPE);
+            let [clearScopeEntry,clearScopeFn] = (storageHandler.update as any).mock.calls[0];
+            const actual = clearScopeFn(cacheBefore);
+            
+            expect(clearScopeEntry).toBe("externals");
+            expect(actual).toEqual(expected);
+        });  
+        
         it('should add externals of RemoteInfo to global scope', () => {
             const SCOPE = MOCK_SCOPE(); 
             const sharedInfo = MOCK_SHARED_INFO({singleton: true, strictVersion: false});
 
-            let actual = {global: {}} as CacheGlobalExternals & CacheScopedExternals
+            let cacheBefore = {
+                global: {},
+                [SCOPE]: {}
+            } as CacheGlobalExternals & CacheScopedExternals
 
             const expected = {
                 global: {
@@ -124,27 +151,23 @@ describe('externalsHandler', () => {
                 [SCOPE]: {}
             }
 
-
             externalsHandler.toStorage(sharedInfo, SCOPE);
 
-            // 1) REMOVE OLD DEPS FROM SCOPE IN STORAGE
-            let [storageEntry1, clearScopeFn] = (storageHandler.update as any).mock.calls[0];
-            actual = clearScopeFn(actual);
-            expect(storageEntry1).toBe("externals");
-            expect(actual).toEqual({global: {}, [SCOPE]: {}});
-
-            // 2) ADD DEPS TO GLOBAL AND REMOTE SCOPE
-            let [storageEntry2, addExternalsFn] = (storageHandler.update as any).mock.calls[1];
-            actual = addExternalsFn(actual);
+            // 'Add dependency to scope' call
+            const [addExternalsEntry, addExternalsFn] = (storageHandler.update as any).mock.calls[1];
+            const actual = addExternalsFn(cacheBefore);
+            
             expect(actual).toEqual(expected);
-            expect(storageEntry2).toBe("externals");
+            expect(addExternalsEntry).toBe("externals");
         });  
 
         it('should add externals of RemoteInfo to scoped storage', () => {
             const SCOPE = MOCK_SCOPE(); 
             const sharedInfo = MOCK_SHARED_INFO({singleton: false, strictVersion: false});
 
-            let actual = {global: {}} as CacheGlobalExternals & CacheScopedExternals
+            let cacheBefore = {
+                global: {}
+            } as CacheGlobalExternals & CacheScopedExternals
 
             const expected = {
                 global: {},
@@ -155,17 +178,12 @@ describe('externalsHandler', () => {
 
             externalsHandler.toStorage(sharedInfo, SCOPE);
 
-            // 1) REMOVE OLD DEPS FROM SCOPE IN STORAGE
-            let [storageEntry1, clearScopeFn] = (storageHandler.update as any).mock.calls[0];
-            actual = clearScopeFn(actual);
-            expect(storageEntry1).toBe("externals");
-            expect(actual).toEqual({global: {}, [SCOPE]: {}});
-
-            // 2) ADD DEPS TO GLOBAL AND SCOPE
-            let [storageEntry2, addExternalsFn] = (storageHandler.update as any).mock.calls[1];
-            actual = addExternalsFn(actual);
+            // 'Add dependency to scope' call
+            let [addExternalsEntry, addExternalsFn] = (storageHandler.update as any).mock.calls[1];
+            const actual = addExternalsFn(cacheBefore);
+            
             expect(actual).toEqual(expected);
-            expect(storageEntry2).toBe("externals");
+            expect(addExternalsEntry).toBe("externals");
         });  
 
         it('should update requiredVersion if version is smaller than current', () => {
@@ -174,86 +192,92 @@ describe('externalsHandler', () => {
             const sharedInfo = MOCK_SHARED_INFO({singleton: true, strictVersion: false, requiredVersion: "~7.7.0"});
 
             versionHandler.getSmallestVersionRange = jest.fn((): string => "^7.7.0");
-
-            let cache = {
+            
+            const cacheBefore = {
                 global: {"rxjs": {version: "7.8.1", requiredVersion: "^7.8.0", url: "http://localhost:3001/rxjs.js" }},
                 [SCOPE]: { }
-            } as CacheGlobalExternals & CacheScopedExternals
-            
+            } as CacheGlobalExternals & CacheScopedExternals; 
+
+            const expected = {
+                global: {"rxjs": {version: "7.8.1", requiredVersion: "^7.7.0", url: "http://localhost:3001/rxjs.js" }},
+                [SCOPE]: { }
+            }; 
+
             versionHandler.compareVersions = jest.fn((_v1, _v2) => 0);
 
             externalsHandler.toStorage(sharedInfo, SCOPE);
 
-            // 1) REMOVE OLD DEPS FROM SCOPE IN STORAGE
-            let [storageEntry1, clearScopeFn] = (storageHandler.update as any).mock.calls[0];
-            const actualAfterScopeClear = clearScopeFn(cache);
-            expect(storageEntry1).toBe("externals");
-            expect(actualAfterScopeClear).toEqual({
-                global: {"rxjs": {version: "7.8.1", requiredVersion: "^7.8.0", url: "http://localhost:3001/rxjs.js" }},
-                [SCOPE]: { }
-            });
-
-            // 2) ADD DEPS TO GLOBAL AND SCOPE
-            let [storageEntry2, addExternalsFn] = (storageHandler.update as any).mock.calls[1];
-            const actualAfterGlobalUpdate = addExternalsFn(cache);
-            expect(actualAfterGlobalUpdate).toEqual({
-                global: {"rxjs": {version: "7.8.1", requiredVersion: "^7.7.0", url: "http://localhost:3001/rxjs.js" }},
-                [SCOPE]: { }
-            });
-            expect(storageEntry2).toBe("externals");
+            // 'Add dependency to scope' call
+            let [addExternalsEntry, addExternalsFn] = (storageHandler.update as any).mock.calls[1];
+            const actual = addExternalsFn(cacheBefore);
+            
+            expect(actual).toEqual(expected);
+            expect(addExternalsEntry).toBe("externals");
         });  
         
-        it('should append new externals to cache', () => {
+        it('should append a dependency to the global scope', () => {
             const SCOPE = MOCK_SCOPE(); 
-            const sharedInfo = MOCK_SHARED_INFO({singleton: true, strictVersion: false});
+            
+            const sharedInfo = MOCK_SHARED_INFO({singleton: true, strictVersion: false });
 
-            const cache = {
-                externals: {
-                    global: {
-                        "rxjs/operators": {version: "7.8.1", requiredVersion: "^7.8.0", url: "http://localhost:3001/rxjs_operators.js"}
-                    }
-                } as CacheGlobalExternals & CacheScopedExternals
-            }
+            const cacheBefore = {
+                global: {
+                    "rxjs/operators": {version: "7.8.1", requiredVersion: "^7.8.0", url: "http://localhost:3001/rxjs_operators.js"}
+                },
+                [SCOPE]: { }
+            } as CacheGlobalExternals & CacheScopedExternals; 
 
-            externalsHandler.toStorage(sharedInfo, SCOPE);
-
-            const [key, mutation] = (storageHandler.update as any).mock.calls[1];
-            const actual = mutation(cache.externals);
-
-            expect(key).toBe("externals");
-            expect(actual).toEqual({
+            const expected = {
                 global: {
                     "rxjs/operators": {version: "7.8.1", requiredVersion: "^7.8.0", url: "http://localhost:3001/rxjs_operators.js"},
                     "rxjs": {version: "7.8.1", requiredVersion: "^7.8.0", url: "http://localhost:3001/rxjs.js" }
-                }
-            });
-        });
+                },
+                [SCOPE]: { }
+            }; 
 
-        it('should append new strict externals to cache', () => {
-            const SCOPE = MOCK_SCOPE(); 
-            const sharedInfo = MOCK_SHARED_INFO({singleton: true, strictVersion: true});
-
-            const cache = {
-                externals: {
-                    global: {
-                        "rxjs/operators": {version: "7.8.1", requiredVersion: "^7.8.0", url: "http://localhost:3001/rxjs_operators.js"}
-                    }
-                } as CacheGlobalExternals & CacheScopedExternals
-            }
+            versionHandler.compareVersions = jest.fn((_v1, _v2) => 0);
 
             externalsHandler.toStorage(sharedInfo, SCOPE);
 
-            const [key, mutation] = (storageHandler.update as any).mock.calls[1];
-            const actual = mutation(cache.externals);
+            // 'Add dependency to scope' call
+            let [addExternalsEntry, addExternalsFn] = (storageHandler.update as any).mock.calls[1];
+            const actual = addExternalsFn(cacheBefore);
+            
+            expect(actual).toEqual(expected);
+            expect(addExternalsEntry).toBe("externals");
+        });  
 
-            expect(key).toBe("externals");
-            expect(actual).toEqual({
+        it('should append a strict dependency to the global scope', () => {
+            const SCOPE = MOCK_SCOPE(); 
+            
+            const sharedInfo = MOCK_SHARED_INFO({singleton: true, strictVersion: true});
+
+            const cacheBefore = {
+                global: {
+                    "rxjs/operators": {version: "7.8.1", requiredVersion: "^7.8.0", url: "http://localhost:3001/rxjs_operators.js"}
+                },
+                [SCOPE]: { }
+            } as CacheGlobalExternals & CacheScopedExternals; 
+
+            const expected = {
                 global: {
                     "rxjs/operators": {version: "7.8.1", requiredVersion: "^7.8.0", url: "http://localhost:3001/rxjs_operators.js"},
                     "rxjs": {version: "7.8.1", strictRequiredVersion: "^7.8.0", url: "http://localhost:3001/rxjs.js" }
-                }
-            });
-        });
+                },
+                [SCOPE]: { }
+            }; 
+
+            versionHandler.compareVersions = jest.fn((_v1, _v2) => 0);
+
+            externalsHandler.toStorage(sharedInfo, SCOPE);
+
+            // 'Add dependency to scope' call
+            let [addExternalsEntry, addExternalsFn] = (storageHandler.update as any).mock.calls[1];
+            const actual = addExternalsFn(cacheBefore);
+            
+            expect(actual).toEqual(expected);
+            expect(addExternalsEntry).toBe("externals");
+        });  
 
         it('should override if the version is newer', () => {
             const SCOPE = MOCK_SCOPE(); 

--- a/src/lib/handlers/externals/externals.handler.ts
+++ b/src/lib/handlers/externals/externals.handler.ts
@@ -80,7 +80,7 @@ const externalsHandlerFactory = (
             }
             if (currentExternal.strictRequiredVersion &&  
                 !versionHandler.isCompatible(newExternal.version!, currentExternal.strictRequiredVersion)) {
-                throw new NFError(`[${newExternal.packageName}] Shared version '${newExternal.version}' is not compatible to version range '${currentExternal.strictRequiredVersion}'`);
+                throw new NFError(`[${newExternal.packageName}] Shared (strict) version '${newExternal.version}' is not compatible to version range '${currentExternal.strictRequiredVersion}'`);
             }
 
             if (currentExternal.requiredVersion && 

--- a/src/lib/handlers/handlers.resolver.ts
+++ b/src/lib/handlers/handlers.resolver.ts
@@ -22,7 +22,7 @@ const resolveHandlers = <TCache extends NfCache>(
     const remoteInfoHandler = remoteInfoHandlerFactory(config, storageHandler);
     const remoteModuleHandler = remoteModuleHandlerFactory(config, storageHandler);
 
-    const importMapHandler = importMapHandlerFactory(config, externalsHandler, remoteInfoHandler);
+    const importMapHandler = importMapHandlerFactory(config, logHandler, externalsHandler, remoteInfoHandler);
 
     return {
         storageHandler,

--- a/src/lib/handlers/import-map/import-map.handler.ts
+++ b/src/lib/handlers/import-map/import-map.handler.ts
@@ -3,9 +3,11 @@ import type { ModuleLoaderConfig } from "../../config/config.contract";
 import * as _path from "../../utils/path";
 import type { ExternalsHandler } from "../externals/externals.contract";
 import type { RemoteInfo, RemoteInfoHandler, RemoteName } from "../remote-info";
+import type { LogHandler } from "../logging";
 
 const importMapHandlerFactory = (
     {importMapType}: ModuleLoaderConfig,
+    logHandler: LogHandler,
     externalsHandler: ExternalsHandler,
     remoteInfoHandler: RemoteInfoHandler
 ): ImportMapHandler => {
@@ -57,6 +59,12 @@ const importMapHandlerFactory = (
 
         return remotes.reduce(
             (importMap: ImportMap, remoteName: string) => {
+                
+                if(!remoteInfoHandler.inStorage(remoteName)) {
+                    logHandler.warn(`Failed to init remote '${remoteName}': not found in storage.`);
+                    return importMap;
+                }
+                
                 const remoteInfo: RemoteInfo = remoteInfoHandler.fromStorage(remoteName);
                 importMap = appendExposedModules(importMap, remoteInfo);
                 importMap = appendScopedExternals(importMap, remoteInfo);

--- a/src/lib/handlers/remote-info/remote-info.handler.spec.ts
+++ b/src/lib/handlers/remote-info/remote-info.handler.spec.ts
@@ -22,7 +22,7 @@ describe('remoteInfoHandler', () => {
             }
         ] as SharedInfo[]
 
-   const MOCK_FEDERATION_INFO = (): {name: string, exposes: ExposesInfo[]} => 
+    const MOCK_FEDERATION_INFO = (): {name: string, exposes: ExposesInfo[]} => 
         JSON.parse(JSON.stringify({
             name: 'team/mfe1', 
             exposes: [{key: './comp', outFileName: 'comp.js'}]
@@ -31,10 +31,10 @@ describe('remoteInfoHandler', () => {
 
 
     const MOCK_FEDERATION_INFO_II = (): {name: string, exposes: ExposesInfo[]} => 
-            JSON.parse(JSON.stringify({
-                name: 'team/mfe2', 
-                exposes: [{key: './comp', outFileName: 'comp.js'}]
-            }))
+        JSON.parse(JSON.stringify({
+            name: 'team/mfe2', 
+            exposes: [{key: './comp', outFileName: 'comp.js'}]
+        }))
 
 
     beforeEach(() => {

--- a/src/lib/steps/1-fetch-remote-entries.ts
+++ b/src/lib/steps/1-fetch-remote-entries.ts
@@ -65,7 +65,7 @@ const fetchRemoteEntries = (
                 .then(addRemoteEntryToStorage(remoteEntry))
                 .catch(e => {
                     const message = (e instanceof Error) ? e.message : String(e);
-                    logHandler.warn(`Failed to init remote '${remoteName}': ${message}.`);
+                    logHandler.error(`Failed to init remote '${remoteName}': ${message}.`);
                     return false;
                 })
         }

--- a/src/lib/steps/1-fetch-remote-entries.ts
+++ b/src/lib/steps/1-fetch-remote-entries.ts
@@ -65,8 +65,7 @@ const fetchRemoteEntries = (
                 .then(addRemoteEntryToStorage(remoteEntry))
                 .catch(e => {
                     const message = (e instanceof Error) ? e.message : String(e);
-                    logHandler.error(`Failed to initialize remote '${remoteName}'.`);
-                    logHandler.debug(`Remote '${remoteName}' init failed: ` + message);
+                    logHandler.warn(`Failed to init remote '${remoteName}': ${message}.`);
                     return false;
                 })
         }

--- a/src/lib/steps/1-fetch-remote-entries.ts
+++ b/src/lib/steps/1-fetch-remote-entries.ts
@@ -15,7 +15,6 @@ const fetchRemoteEntries = (
                 ...manifest 
             })
         
-
         const fetchManifest = (): Promise<Record<RemoteName, RemoteEntry>> => {
             if (typeof remotesOrManifestUrl !== 'string') 
                 return Promise.resolve(remotesOrManifestUrl);
@@ -65,7 +64,7 @@ const fetchRemoteEntries = (
                 .then(addRemoteEntryToStorage(remoteEntry))
                 .catch(e => {
                     const message = (e instanceof Error) ? e.message : String(e);
-                    logHandler.error(`Failed to init remote '${remoteName}': ${message}.`);
+                    logHandler.error(`Error while verifying remoteEntry.json of '${remoteName}': ${message}.`);
                     return false;
                 })
         }

--- a/src/lib/steps/3-expose-module-loader.ts
+++ b/src/lib/steps/3-expose-module-loader.ts
@@ -10,11 +10,14 @@ type ExposeModuleLoader = (manifest: Record<RemoteName, RemoteEntry>) => Promise
 }>
 
 const exposeModuleLoader = (
-    { logHandler, remoteModuleHandler}: Handlers
+    { logHandler, remoteModuleHandler, remoteInfoHandler }: Handlers
 ): ExposeModuleLoader => {
     function loadRemoteModule(
         remoteName: string, exposedModule: string
     ): Promise<unknown> {
+        if(!remoteInfoHandler.inStorage(remoteName)) {
+            return Promise.reject(new Error(`Remote '${remoteName}' is not initialized.`))
+        }
         try{
             const remoteModule = remoteModuleHandler.fromStorage(remoteName, exposedModule);
             logHandler.debug(`Loading initialized module '${JSON.stringify(remoteModule)}'`);


### PR DESCRIPTION
## Motivation

During the initialization phase, the orchestrator should notify the user whenever a remote could not be initialized because the remoteEntry is not available or the singleton dependencies are incompatible with the current import map. However, the initialization should not fail since the remote modules have not been loaded. Therefore the thrown error was replaced by a warning log and the `loadRemoteModule` received an extra check if the remote was correctly initialized before loading the requested module.

## Changes

- [fix] Init will now only log an error and a warning if a module could not be initialized instead of throwing an error during init.
- [test] Cleaned the test in externals handler.
