### PR TITLE
Feat: sharedScope

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vanilla-native-federation",
-  "version": "0.12.6",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vanilla-native-federation",
-      "version": "0.12.6",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.7.1"
@@ -62,9 +62,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.2.tgz",
-      "integrity": "sha512-TUtMJYRPyUb/9aU8f3K0mjmjf6M9N5Woshn2CS6nqJSeJtTtQcpLUXjGt9vbF8ZGff0El99sWkLgzwW3VXnxZQ==",
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.5.tgz",
+      "integrity": "sha512-KiRAp/VoJaWkkte84TvUd9qjdbZAdiqyvMxrGl1N6vzFogKmaLgoM3L1kgtLicp2HP5fBJS8JrZKLVIZGVJAVg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -72,22 +72,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.1.tgz",
-      "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
+      "version": "7.27.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
+      "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.27.1",
-        "@babel/helper-compilation-targets": "^7.27.1",
-        "@babel/helper-module-transforms": "^7.27.1",
-        "@babel/helpers": "^7.27.1",
-        "@babel/parser": "^7.27.1",
-        "@babel/template": "^7.27.1",
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1",
+        "@babel/generator": "^7.27.3",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.27.3",
+        "@babel/helpers": "^7.27.4",
+        "@babel/parser": "^7.27.4",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.27.4",
+        "@babel/types": "^7.27.3",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -113,14 +113,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.1.tgz",
-      "integrity": "sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==",
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.5.tgz",
+      "integrity": "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.1",
-        "@babel/types": "^7.27.1",
+        "@babel/parser": "^7.27.5",
+        "@babel/types": "^7.27.3",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -171,15 +171,15 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.1.tgz",
-      "integrity": "sha512-9yHn519/8KvTU5BjTVEEeIM3w9/2yXNKoD82JifINImhpKkARMJKPP59kLo+BafpdN5zgNeIcS4jsGDmd3l58g==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
+      "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
+        "@babel/traverse": "^7.27.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -229,27 +229,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.1.tgz",
-      "integrity": "sha512-FCvFTm0sWV8Fxhpp2McP5/W53GPllQ9QeQ7SiqGWjMf/LVG07lFa5+pgK05IRhVwtvafT22KF+ZSnM9I545CvQ==",
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
+      "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.27.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.2.tgz",
-      "integrity": "sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==",
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
+      "integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.1"
+        "@babel/types": "^7.27.3"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -513,17 +513,17 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.1.tgz",
-      "integrity": "sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==",
+      "version": "7.27.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.4.tgz",
+      "integrity": "sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.27.1",
-        "@babel/parser": "^7.27.1",
-        "@babel/template": "^7.27.1",
-        "@babel/types": "^7.27.1",
+        "@babel/generator": "^7.27.3",
+        "@babel/parser": "^7.27.4",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.27.3",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -542,9 +542,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.1.tgz",
-      "integrity": "sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==",
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.6.tgz",
+      "integrity": "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -562,10 +562,316 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.3.tgz",
+      "integrity": "sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz",
+      "integrity": "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.2.tgz",
+      "integrity": "sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
+      "integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz",
+      "integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz",
+      "integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz",
+      "integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
+      "integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz",
+      "integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz",
+      "integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz",
+      "integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz",
+      "integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz",
+      "integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz",
+      "integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz",
+      "integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz",
+      "integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz",
+      "integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz",
+      "integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz",
+      "integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.4.tgz",
-      "integrity": "sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz",
+      "integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
       "cpu": [
         "x64"
       ],
@@ -574,6 +880,142 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz",
+      "integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz",
+      "integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz",
+      "integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz",
+      "integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
+      "integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz",
+      "integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz",
+      "integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz",
+      "integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -729,9 +1171,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.27.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.27.0.tgz",
-      "integrity": "sha512-G5JD9Tu5HJEu4z2Uo4aHY2sLV64B7CDMXxFzqzjl3NKd6RVzSXNoE80jk7Y0lJkTTkjiIhBAqmlYwjuBY3tvpA==",
+      "version": "9.28.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.28.0.tgz",
+      "integrity": "sha512-fnqSjGWd/CoIp4EXIxWVK/sHA6DOHN4+8Ix2cX5ycOY7LG0UY8nHCU5pIp2eaE1Mc7Qd8kHspYNzYXT2ojPLzg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1293,6 +1735,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.10.tgz",
+      "integrity": "sha512-bCsCyeZEwVErsGmyPNSzwfwFn4OdxBj0mmv6hOFucB/k81Ojdu68RbZdxYsRQUPc9l6SU5F/cG+bXgWs3oUgsQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.9.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1332,9 +1787,9 @@
       }
     },
     "node_modules/@pkgr/core": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.4.tgz",
-      "integrity": "sha512-ROFF39F6ZrnzSUEmQQZUar0Jt4xVoP9WnDRdWwF4NNcXs3xBTLgBUDoOwW141y1jP+S8nahIbdxbFC7IShw9Iw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.7.tgz",
+      "integrity": "sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1390,6 +1845,17 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
+      "integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1436,9 +1902,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1510,9 +1976,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.18.tgz",
-      "integrity": "sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg==",
+      "version": "22.15.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
+      "integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1558,17 +2024,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.32.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.32.1.tgz",
-      "integrity": "sha512-6u6Plg9nP/J1GRpe/vcjjabo6Uc5YQPAMxsgQyGC/I0RuukiG1wIe3+Vtg3IrSCVJDmqK3j8adrtzXSENRtFgg==",
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.33.1.tgz",
+      "integrity": "sha512-TDCXj+YxLgtvxvFlAvpoRv9MAncDLBV2oT9Bd7YBGC/b/sEURoOYuIwLI99rjWOfY3QtDzO+mk0n4AmdFExW8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.32.1",
-        "@typescript-eslint/type-utils": "8.32.1",
-        "@typescript-eslint/utils": "8.32.1",
-        "@typescript-eslint/visitor-keys": "8.32.1",
+        "@typescript-eslint/scope-manager": "8.33.1",
+        "@typescript-eslint/type-utils": "8.33.1",
+        "@typescript-eslint/utils": "8.33.1",
+        "@typescript-eslint/visitor-keys": "8.33.1",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -1582,22 +2048,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+        "@typescript-eslint/parser": "^8.33.1",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.32.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.32.1.tgz",
-      "integrity": "sha512-LKMrmwCPoLhM45Z00O1ulb6jwyVr2kr3XJp+G+tSEZcbauNnScewcQwtJqXDhXeYPDEjZ8C1SjXm015CirEmGg==",
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.33.1.tgz",
+      "integrity": "sha512-qwxv6dq682yVvgKKp2qWwLgRbscDAYktPptK4JPojCwwi3R9cwrvIxS4lvBpzmcqzR4bdn54Z0IG1uHFskW4dA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.32.1",
-        "@typescript-eslint/types": "8.32.1",
-        "@typescript-eslint/typescript-estree": "8.32.1",
-        "@typescript-eslint/visitor-keys": "8.32.1",
+        "@typescript-eslint/scope-manager": "8.33.1",
+        "@typescript-eslint/types": "8.33.1",
+        "@typescript-eslint/typescript-estree": "8.33.1",
+        "@typescript-eslint/visitor-keys": "8.33.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1612,15 +2078,37 @@
         "typescript": ">=4.8.4 <5.9.0"
       }
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.32.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.32.1.tgz",
-      "integrity": "sha512-7IsIaIDeZn7kffk7qXC3o6Z4UblZJKV3UBpkvRNpr5NSyLji7tvTcvmnMNYuYLyh26mN8W723xpo3i4MlD33vA==",
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.33.1.tgz",
+      "integrity": "sha512-DZR0efeNklDIHHGRpMpR5gJITQpu6tLr9lDJnKdONTC7vvzOlLAG/wcfxcdxEWrbiZApcoBCzXqU/Z458Za5Iw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.32.1",
-        "@typescript-eslint/visitor-keys": "8.32.1"
+        "@typescript-eslint/tsconfig-utils": "^8.33.1",
+        "@typescript-eslint/types": "^8.33.1",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.33.1.tgz",
+      "integrity": "sha512-dM4UBtgmzHR9bS0Rv09JST0RcHYearoEoo3pG5B6GoTR9XcyeqX87FEhPo+5kTvVfKCvfHaHrcgeJQc6mrDKrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.33.1",
+        "@typescript-eslint/visitor-keys": "8.33.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1630,15 +2118,32 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.33.1.tgz",
+      "integrity": "sha512-STAQsGYbHCF0/e+ShUQ4EatXQ7ceh3fBCXkNU7/MZVKulrlq1usH7t2FhxvCpuCi5O5oi1vmVaAjrGeL71OK1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.32.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.32.1.tgz",
-      "integrity": "sha512-mv9YpQGA8iIsl5KyUPi+FGLm7+bA4fgXaeRcFKRDRwDMu4iwrSHeDPipwueNXhdIIZltwCJv+NkxftECbIZWfA==",
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.33.1.tgz",
+      "integrity": "sha512-1cG37d9xOkhlykom55WVwG2QRNC7YXlxMaMzqw2uPeJixBFfKWZgaP/hjAObqMN/u3fr5BrTwTnc31/L9jQ2ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.32.1",
-        "@typescript-eslint/utils": "8.32.1",
+        "@typescript-eslint/typescript-estree": "8.33.1",
+        "@typescript-eslint/utils": "8.33.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -1655,9 +2160,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.32.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.32.1.tgz",
-      "integrity": "sha512-YmybwXUJcgGqgAp6bEsgpPXEg6dcCyPyCSr0CAAueacR/CCBi25G3V8gGQ2kRzQRBNol7VQknxMs9HvVa9Rvfg==",
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.33.1.tgz",
+      "integrity": "sha512-xid1WfizGhy/TKMTwhtVOgalHwPtV8T32MS9MaH50Cwvz6x6YqRIPdD2WvW0XaqOzTV9p5xdLY0h/ZusU5Lokg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1669,14 +2174,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.32.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.32.1.tgz",
-      "integrity": "sha512-Y3AP9EIfYwBb4kWGb+simvPaqQoT5oJuzzj9m0i6FCY6SPvlomY2Ei4UEMm7+FXtlNJbor80ximyslzaQF6xhg==",
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.33.1.tgz",
+      "integrity": "sha512-+s9LYcT8LWjdYWu7IWs7FvUxpQ/DGkdjZeE/GGulHvv8rvYwQvVaUZ6DE+j5x/prADUgSbbCWZ2nPI3usuVeOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.32.1",
-        "@typescript-eslint/visitor-keys": "8.32.1",
+        "@typescript-eslint/project-service": "8.33.1",
+        "@typescript-eslint/tsconfig-utils": "8.33.1",
+        "@typescript-eslint/types": "8.33.1",
+        "@typescript-eslint/visitor-keys": "8.33.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -1696,16 +2203,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.32.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.32.1.tgz",
-      "integrity": "sha512-DsSFNIgLSrc89gpq1LJB7Hm1YpuhK086DRDJSNrewcGvYloWW1vZLHBTIvarKZDcAORIy/uWNx8Gad+4oMpkSA==",
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.33.1.tgz",
+      "integrity": "sha512-52HaBiEQUaRYqAXpfzWSR2U3gxk92Kw006+xZpElaPMg3C4PgM+A5LqwoQI1f9E5aZ/qlxAZxzm42WX+vn92SQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.32.1",
-        "@typescript-eslint/types": "8.32.1",
-        "@typescript-eslint/typescript-estree": "8.32.1"
+        "@typescript-eslint/scope-manager": "8.33.1",
+        "@typescript-eslint/types": "8.33.1",
+        "@typescript-eslint/typescript-estree": "8.33.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1720,13 +2227,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.32.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.32.1.tgz",
-      "integrity": "sha512-ar0tjQfObzhSaW3C3QNmTc5ofj0hDoNQ5XWrCy6zDyabdr0TWhCkClp+rywGNj/odAFBVzzJrK4tEq5M4Hmu4w==",
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.33.1.tgz",
+      "integrity": "sha512-3i8NrFcZeeDHJ+7ZUuDkGT+UHq+XoFGsymNK2jZCOHcfEzRQ0BdpRtdpSx/Iyf3MHLWIcLS0COuOPibKQboIiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.32.1",
+        "@typescript-eslint/types": "8.33.1",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -1750,10 +2257,164 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.7.11.tgz",
+      "integrity": "sha512-i3/wlWjQJXMh1uiGtiv7k1EYvrrS3L1hdwmWJJiz1D8jWy726YFYPIxQWbEIVPVAgrfRR0XNlLrTQwq17cuCGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.7.11.tgz",
+      "integrity": "sha512-8XXyFvc6w6kmMmi6VYchZhjd5CDcp+Lv6Cn1YmUme0ypsZ/0Kzd+9ESrWtDrWibKPTgSteDTxp75cvBOY64FQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.7.11.tgz",
+      "integrity": "sha512-0qJBYzP8Qk24CZ05RSWDQUjdiQUeIJGfqMMzbtXgCKl/a5xa6thfC0MQkGIr55LCLd6YmMyO640ifYUa53lybQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.7.11.tgz",
+      "integrity": "sha512-1sGwpgvx+WZf0GFT6vkkOm6UJ+mlsVnjw+Yv9esK71idWeRAG3bbpkf3AoY8KIqKqmnzJExi0uKxXpakQ5Pcbg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.7.11.tgz",
+      "integrity": "sha512-D/1F/2lTe+XAl3ohkYj51NjniVly8sIqkA/n1aOND3ZMO418nl2JNU95iVa1/RtpzaKcWEsNTtHRogykrUflJg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.7.11.tgz",
+      "integrity": "sha512-7vFWHLCCNFLEQlmwKQfVy066ohLLArZl+AV/AdmrD1/pD1FlmqM+FKbtnONnIwbHtgetFUCV/SRi1q4D49aTlw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.7.11.tgz",
+      "integrity": "sha512-tYkGIx8hjWPh4zcn17jLEHU8YMmdP2obRTGkdaB3BguGHh31VCS3ywqC4QjTODjmhhNyZYkj/1Dz/+0kKvg9YA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.7.11.tgz",
+      "integrity": "sha512-6F328QIUev29vcZeRX6v6oqKxfUoGwIIAhWGD8wSysnBYFY0nivp25jdWmAb1GildbCCaQvOKEhCok7YfWkj4Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.7.11.tgz",
+      "integrity": "sha512-NqhWmiGJGdzbZbeucPZIG9Iav4lyYLCarEnxAceguMx9qlpeEF7ENqYKOwB8Zqk7/CeuYMEcLYMaW2li6HyDzQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.7.11.tgz",
+      "integrity": "sha512-J2RPIFKMdTrLtBdfR1cUMKl8Gcy05nlQ+bEs/6al7EdWLk9cs3tnDREHZ7mV9uGbeghpjo4i8neNZNx3PYUY9w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.7.11.tgz",
+      "integrity": "sha512-bDpGRerHvvHdhun7MmFUNDpMiYcJSqWckwAVVRTJf8F+RyqYJOp/mx04PDc7DhpNPeWdnTMu91oZRMV+gGaVcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.7.2.tgz",
-      "integrity": "sha512-dEidzJDubxxhUCBJ/SHSMJD/9q7JkyfBMT77Px1npl4xpg9t0POLvnWywSk66BgZS/b2Hy9Y1yFaoMTFJUe9yg==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.7.11.tgz",
+      "integrity": "sha512-G9U7bVmylzRLma3cK39RBm3guoD1HOvY4o0NS4JNm37AD0lS7/xyMt7kn0JejYyc0Im8J+rH69/dXGM9DAJcSQ==",
       "cpu": [
         "x64"
       ],
@@ -1765,9 +2426,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.7.2.tgz",
-      "integrity": "sha512-RvP+Ux3wDjmnZDT4XWFfNBRVG0fMsc+yVzNFUqOflnDfZ9OYujv6nkh+GOr+watwrW4wdp6ASfG/e7bkDradsw==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.7.11.tgz",
+      "integrity": "sha512-7qL20SBKomekSunm7M9Fe5L93bFbn+FbHiGJbfTlp0RKhPVoJDP73vOxf1QrmJHyDPECsGWPFnKa/f8fO2FsHw==",
       "cpu": [
         "x64"
       ],
@@ -1776,6 +2437,65 @@
       "optional": true,
       "os": [
         "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.7.11.tgz",
+      "integrity": "sha512-jisvIva8MidjI+B1lFRZZMfCPaCISePgTyR60wNT1MeQvIh5Ksa0G3gvI+Iqyj3jqYbvOHByenpa5eDGcSdoSg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.10"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.7.11.tgz",
+      "integrity": "sha512-G+H5nQZ8sRZ8ebMY6mRGBBvTEzMYEcgVauLsNHpvTUavZoCCRVP1zWkCZgOju2dW3O22+8seTHniTdl1/uLz3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.7.11.tgz",
+      "integrity": "sha512-Hfy46DBfFzyv0wgR0MMOwFFib2W2+Btc8oE5h4XlPhpelnSyA6nFxkVIyTgIXYGTdFaLoZFNn62fmqx3rjEg3A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.7.11.tgz",
+      "integrity": "sha512-7L8NdsQlCJ8T106Gbz/AjzM4QKWVsoQbKpB9bMBGcIZswUuAnJMHpvbqGW3RBqLHCIwX4XZ5fxSBHEFcK2h9wA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@zeit/schemas": {
@@ -2240,9 +2960,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
-      "integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
+      "integrity": "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==",
       "dev": true,
       "funding": [
         {
@@ -2260,8 +2980,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001716",
-        "electron-to-chromium": "^1.5.149",
+        "caniuse-lite": "^1.0.30001718",
+        "electron-to-chromium": "^1.5.160",
         "node-releases": "^2.0.19",
         "update-browserslist-db": "^1.1.3"
       },
@@ -2347,9 +3067,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001718",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
-      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
+      "version": "1.0.30001721",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001721.tgz",
+      "integrity": "sha512-cOuvmUVtKrtEaoKiO0rSc29jcjwMwX5tOHDy4MgVFEWiUXj4uBMJkwI8MDySkgXidpMiHUcviogAvFi4pA2hDQ==",
       "dev": true,
       "funding": [
         {
@@ -2872,9 +3592,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.155",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.155.tgz",
-      "integrity": "sha512-ps5KcGGmwL8VaeJlvlDlu4fORQpv3+GIcF5I3f9tUKUlJ/wsysh6HU8P5L1XWRYeXfA0oJd4PyM8ds8zTFf6Ng==",
+      "version": "1.5.165",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.165.tgz",
+      "integrity": "sha512-naiMx1Z6Nb2TxPU6fiFrUrDTjyPMLdTtaOd2oLmG8zVSg2hCWGkhPyxwk+qRmZ1ytwVqUv0u7ZcDA5+ALhaUtw==",
       "dev": true,
       "license": "ISC"
     },
@@ -2942,9 +3662,9 @@
       }
     },
     "node_modules/es-module-shims": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-2.5.1.tgz",
-      "integrity": "sha512-rx57z9aYi2XWJggkIoR0knHT2yr9kQ1vyXkva+oMNlplJr46Aj/1CI6c+GHGxEH6ljzoEhtAYxk080U5NpUpmg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-2.6.0.tgz",
+      "integrity": "sha512-R5TdSd1rN4ok3gUEpG4H8JmrfexQf06yJ1c3VY3xqxt+S4rsaN0wzMHo4XnDtrX/zxOO0B9VhG/pFbsJ8WRvpg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2978,9 +3698,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.4.tgz",
-      "integrity": "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
+      "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2991,31 +3711,31 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.4",
-        "@esbuild/android-arm": "0.25.4",
-        "@esbuild/android-arm64": "0.25.4",
-        "@esbuild/android-x64": "0.25.4",
-        "@esbuild/darwin-arm64": "0.25.4",
-        "@esbuild/darwin-x64": "0.25.4",
-        "@esbuild/freebsd-arm64": "0.25.4",
-        "@esbuild/freebsd-x64": "0.25.4",
-        "@esbuild/linux-arm": "0.25.4",
-        "@esbuild/linux-arm64": "0.25.4",
-        "@esbuild/linux-ia32": "0.25.4",
-        "@esbuild/linux-loong64": "0.25.4",
-        "@esbuild/linux-mips64el": "0.25.4",
-        "@esbuild/linux-ppc64": "0.25.4",
-        "@esbuild/linux-riscv64": "0.25.4",
-        "@esbuild/linux-s390x": "0.25.4",
-        "@esbuild/linux-x64": "0.25.4",
-        "@esbuild/netbsd-arm64": "0.25.4",
-        "@esbuild/netbsd-x64": "0.25.4",
-        "@esbuild/openbsd-arm64": "0.25.4",
-        "@esbuild/openbsd-x64": "0.25.4",
-        "@esbuild/sunos-x64": "0.25.4",
-        "@esbuild/win32-arm64": "0.25.4",
-        "@esbuild/win32-ia32": "0.25.4",
-        "@esbuild/win32-x64": "0.25.4"
+        "@esbuild/aix-ppc64": "0.25.5",
+        "@esbuild/android-arm": "0.25.5",
+        "@esbuild/android-arm64": "0.25.5",
+        "@esbuild/android-x64": "0.25.5",
+        "@esbuild/darwin-arm64": "0.25.5",
+        "@esbuild/darwin-x64": "0.25.5",
+        "@esbuild/freebsd-arm64": "0.25.5",
+        "@esbuild/freebsd-x64": "0.25.5",
+        "@esbuild/linux-arm": "0.25.5",
+        "@esbuild/linux-arm64": "0.25.5",
+        "@esbuild/linux-ia32": "0.25.5",
+        "@esbuild/linux-loong64": "0.25.5",
+        "@esbuild/linux-mips64el": "0.25.5",
+        "@esbuild/linux-ppc64": "0.25.5",
+        "@esbuild/linux-riscv64": "0.25.5",
+        "@esbuild/linux-s390x": "0.25.5",
+        "@esbuild/linux-x64": "0.25.5",
+        "@esbuild/netbsd-arm64": "0.25.5",
+        "@esbuild/netbsd-x64": "0.25.5",
+        "@esbuild/openbsd-arm64": "0.25.5",
+        "@esbuild/openbsd-x64": "0.25.5",
+        "@esbuild/sunos-x64": "0.25.5",
+        "@esbuild/win32-arm64": "0.25.5",
+        "@esbuild/win32-ia32": "0.25.5",
+        "@esbuild/win32-x64": "0.25.5"
       }
     },
     "node_modules/escalade": {
@@ -3064,9 +3784,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.27.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.27.0.tgz",
-      "integrity": "sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==",
+      "version": "9.28.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.28.0.tgz",
+      "integrity": "sha512-ocgh41VhRlf9+fVpe7QKzwLj9c92fDiqOj8Y3Sd4/ZmVA4Btx4PlUYPq4pp9JDyupkf1upbEXecxL2mwNV7jPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3076,7 +3796,7 @@
         "@eslint/config-helpers": "^0.2.1",
         "@eslint/core": "^0.14.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.27.0",
+        "@eslint/js": "9.28.0",
         "@eslint/plugin-kit": "^0.3.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -3124,19 +3844,45 @@
         }
       }
     },
+    "node_modules/eslint-import-context": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.8.tgz",
+      "integrity": "sha512-bq+F7nyc65sKpZGT09dY0S0QrOnQtuDVIfyTGQ8uuvtMIF7oHp6CEP3mouN0rrnYF3Jqo6Ke0BfU/5wASZue1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-tsconfig": "^4.10.1",
+        "stable-hash-x": "^0.1.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-context"
+      },
+      "peerDependencies": {
+        "unrs-resolver": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "unrs-resolver": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-import-resolver-typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.3.5.tgz",
-      "integrity": "sha512-QGwhLrwn/WGOsdrWvjhm9n8BvKN/Wr41SQERMV7DQ2hm9+Ozas39CyQUxum///l2G2vefQVr7VbIaCFS5h9g5g==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.3.tgz",
+      "integrity": "sha512-elVDn1eWKFrWlzxlWl9xMt8LltjKl161Ix50JFC50tHXI5/TRP32SNEqlJ/bo/HV+g7Rou/tlPQU2AcRtIhrOg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "debug": "^4.4.0",
-        "get-tsconfig": "^4.10.0",
+        "debug": "^4.4.1",
+        "eslint-import-context": "^0.1.8",
+        "get-tsconfig": "^4.10.1",
         "is-bun-module": "^2.0.0",
-        "stable-hash": "^0.0.5",
-        "tinyglobby": "^0.2.13",
-        "unrs-resolver": "^1.6.3"
+        "stable-hash-x": "^0.1.1",
+        "tinyglobby": "^0.2.14",
+        "unrs-resolver": "^1.7.11"
       },
       "engines": {
         "node": "^16.17.0 || >=18.6.0"
@@ -3159,14 +3905,14 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.4.0.tgz",
-      "integrity": "sha512-BvQOvUhkVQM1i63iMETK9Hjud9QhqBnbtT1Zc642p9ynzBuCe5pybkOnvqZIBypXmMlsGcnU4HZ8sCTPfpAexA==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.4.1.tgz",
+      "integrity": "sha512-9dF+KuU/Ilkq27A8idRP7N2DH8iUR6qXcjF3FR2wETY21PZdBrIjwCau8oboyGj9b7etWmTGEeM8e7oOed6ZWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "prettier-linter-helpers": "^1.0.0",
-        "synckit": "^0.11.0"
+        "synckit": "^0.11.7"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -3573,15 +4319,16 @@
       "license": "ISC"
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -3594,6 +4341,21 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -3688,9 +4450,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.0.tgz",
-      "integrity": "sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3924,9 +4686,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.4.tgz",
-      "integrity": "sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6198,12 +6960,15 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/stable-hash": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
-      "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+    "node_modules/stable-hash-x": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.1.1.tgz",
+      "integrity": "sha512-l0x1D6vhnsNUGPFVDx45eif0y6eedVC8nm5uACTrVFJFtl2mLRW17aWtVyxFCpn5t94VUPkjU8vSLwIuwwqtJQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -6369,9 +7134,9 @@
       "license": "MIT"
     },
     "node_modules/synckit": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.6.tgz",
-      "integrity": "sha512-2pR2ubZSV64f/vqm9eLPz/KOvR9Dm+Co/5ChLgeHl0yEDRc6h5hXHoxEQH8Y5Ljycozd3p1k5TTSVdzYGkPvLw==",
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.8.tgz",
+      "integrity": "sha512-+XZ+r1XGIJGeQk3VvXhT6xx/VpbHsRzsTkGgF6E5RX9TTXD0118l87puaEBZ566FhqblC6U0d4XnubznJDm30A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6431,9 +7196,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
-      "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6448,9 +7213,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
-      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
+      "integrity": "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -6675,9 +7440,9 @@
       }
     },
     "node_modules/unrs-resolver": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.7.2.tgz",
-      "integrity": "sha512-BBKpaylOW8KbHsu378Zky/dGh4ckT/4NW/0SHRABdqRLcQJ2dAOjDo9g97p04sWflm0kqPqpUatxReNV/dqI5A==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.7.11.tgz",
+      "integrity": "sha512-OhuAzBImFPjKNgZ2JwHMfGFUA6NSbRegd1+BPjC1Y0E6X9Y/vJ4zKeGmIMqmlYboj6cMNEwKI+xQisrg4J0HaQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -6685,26 +7450,26 @@
         "napi-postinstall": "^0.2.2"
       },
       "funding": {
-        "url": "https://github.com/sponsors/JounQin"
+        "url": "https://opencollective.com/unrs-resolver"
       },
       "optionalDependencies": {
-        "@unrs/resolver-binding-darwin-arm64": "1.7.2",
-        "@unrs/resolver-binding-darwin-x64": "1.7.2",
-        "@unrs/resolver-binding-freebsd-x64": "1.7.2",
-        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.7.2",
-        "@unrs/resolver-binding-linux-arm-musleabihf": "1.7.2",
-        "@unrs/resolver-binding-linux-arm64-gnu": "1.7.2",
-        "@unrs/resolver-binding-linux-arm64-musl": "1.7.2",
-        "@unrs/resolver-binding-linux-ppc64-gnu": "1.7.2",
-        "@unrs/resolver-binding-linux-riscv64-gnu": "1.7.2",
-        "@unrs/resolver-binding-linux-riscv64-musl": "1.7.2",
-        "@unrs/resolver-binding-linux-s390x-gnu": "1.7.2",
-        "@unrs/resolver-binding-linux-x64-gnu": "1.7.2",
-        "@unrs/resolver-binding-linux-x64-musl": "1.7.2",
-        "@unrs/resolver-binding-wasm32-wasi": "1.7.2",
-        "@unrs/resolver-binding-win32-arm64-msvc": "1.7.2",
-        "@unrs/resolver-binding-win32-ia32-msvc": "1.7.2",
-        "@unrs/resolver-binding-win32-x64-msvc": "1.7.2"
+        "@unrs/resolver-binding-darwin-arm64": "1.7.11",
+        "@unrs/resolver-binding-darwin-x64": "1.7.11",
+        "@unrs/resolver-binding-freebsd-x64": "1.7.11",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.7.11",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.7.11",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.7.11",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.7.11",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.7.11",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.7.11",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.7.11",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.7.11",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.7.11",
+        "@unrs/resolver-binding-linux-x64-musl": "1.7.11",
+        "@unrs/resolver-binding-wasm32-wasi": "1.7.11",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.7.11",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.7.11",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.7.11"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.12.7",
+  "version": "0.13.0",
   "name": "vanilla-native-federation",
   "author": "aukevanoost",
   "keywords": [

--- a/src/lib/1.domain/externals/external.contract.ts
+++ b/src/lib/1.domain/externals/external.contract.ts
@@ -4,11 +4,15 @@ export type ExternalName = string;
 
 export type ScopedExternals = Record<string, ExternalsScope>
 
+export const GLOBAL_SCOPE = "__GLOBAL__";
+
 export type SharedExternal = {
     dirty: boolean,
     versions: SharedVersion[]
 }
 
-export type SharedExternals = Record<string, SharedExternal>
+export type SharedScope = Record<string, SharedExternal>
+
+export type SharedExternals = Record<string, SharedScope> & {[GLOBAL_SCOPE]: SharedScope}
 
 export type ExternalsScope = Record<string, Version>

--- a/src/lib/1.domain/remote-entry/remote-entry.contract.ts
+++ b/src/lib/1.domain/remote-entry/remote-entry.contract.ts
@@ -1,11 +1,28 @@
-import type { FederationInfo } from "@softarc/native-federation-runtime";
 import type { RemoteEntryUrl } from "./manifest.contract";
+import type { ExposesInfo } from "@softarc/native-federation-runtime";
+
+type SharedInfo = {
+    singleton: boolean;
+    strictVersion: boolean;
+    requiredVersion: string;
+    version?: string;
+    packageName: string;
+    outFileName: string;
+    sharedScope?: string;
+    dev?: {
+        entryPoint: string;
+    };
+};
+
+interface FederationInfo {
+    name: string;
+    exposes: ExposesInfo[];
+    shared: SharedInfo[];
+}
 
 type RemoteEntry = FederationInfo & {
     url: RemoteEntryUrl,
     host?: boolean,
 }
 
-export { RemoteEntry, FederationInfo }
-
-export { ExposesInfo, SharedInfo } from "@softarc/native-federation-runtime";
+export { RemoteEntry, FederationInfo, ExposesInfo, SharedInfo }

--- a/src/lib/2.app/determine-shared-externals.precedence.spec.ts
+++ b/src/lib/2.app/determine-shared-externals.precedence.spec.ts
@@ -92,7 +92,8 @@ describe('createDetermineSharedExternals (compatibility precedence)', () => {
                         action: "share"
                     },
                 ]
-            }
+            },
+            GLOBAL_SCOPE
         )
     });
 
@@ -149,7 +150,8 @@ describe('createDetermineSharedExternals (compatibility precedence)', () => {
                         action: "skip"
                     },
                 ]
-            }
+            },
+            GLOBAL_SCOPE
         )
     });
 
@@ -227,7 +229,8 @@ describe('createDetermineSharedExternals (compatibility precedence)', () => {
                         action: "skip"
                     },
                 ]
-            }
+            },
+            GLOBAL_SCOPE
         )
     });
 
@@ -306,7 +309,8 @@ describe('createDetermineSharedExternals (compatibility precedence)', () => {
                         action: "scope"
                     },
                 ]
-            }
+            },
+            GLOBAL_SCOPE
         )
     });
 

--- a/src/lib/2.app/determine-shared-externals.precedence.spec.ts
+++ b/src/lib/2.app/determine-shared-externals.precedence.spec.ts
@@ -5,6 +5,7 @@ import { mockSharedExternalsRepository } from 'lib/6.mocks/adapters/shared-exter
 import { createVersionCheck } from 'lib/3.adapters/checks/version.check';
 import { LoggingConfig } from './config/log.contract';
 import { ModeConfig } from './config/mode.contract';
+import { GLOBAL_SCOPE } from 'lib/1.domain';
 
 
 /**
@@ -34,7 +35,7 @@ describe('createDetermineSharedExternals (compatibility precedence)', () => {
             versionCheck: createVersionCheck(),
             sharedExternalsRepo: mockSharedExternalsRepository()
         };
-        
+        mockAdapters.sharedExternalsRepo.getScopes = jest.fn(() => [GLOBAL_SCOPE])
         determineSharedExternals = createDetermineSharedExternals(mockConfig, mockAdapters);
     });
 

--- a/src/lib/2.app/determine-shared-externals.spec.ts
+++ b/src/lib/2.app/determine-shared-externals.spec.ts
@@ -6,6 +6,7 @@ import { createVersionCheck } from 'lib/3.adapters/checks/version.check';
 import { LoggingConfig } from './config/log.contract';
 import { ModeConfig } from './config/mode.contract';
 import { NFError } from 'lib/native-federation.error';
+import { GLOBAL_SCOPE } from 'lib/1.domain';
 
 describe('createDetermineSharedExternals', () => {
     let determineSharedExternals: ForDeterminingSharedExternals;
@@ -31,6 +32,7 @@ describe('createDetermineSharedExternals', () => {
             versionCheck: createVersionCheck(),
             sharedExternalsRepo: mockSharedExternalsRepository()
         };
+        mockAdapters.sharedExternalsRepo.getScopes = jest.fn(() => [GLOBAL_SCOPE])
         
         determineSharedExternals = createDetermineSharedExternals(mockConfig, mockAdapters);
     });

--- a/src/lib/2.app/determine-shared-externals.spec.ts
+++ b/src/lib/2.app/determine-shared-externals.spec.ts
@@ -6,7 +6,7 @@ import { createVersionCheck } from 'lib/3.adapters/checks/version.check';
 import { LoggingConfig } from './config/log.contract';
 import { ModeConfig } from './config/mode.contract';
 import { NFError } from 'lib/native-federation.error';
-import { GLOBAL_SCOPE } from 'lib/1.domain';
+import { GLOBAL_SCOPE, SharedScope } from 'lib/1.domain';
 
 describe('createDetermineSharedExternals', () => {
     let determineSharedExternals: ForDeterminingSharedExternals;
@@ -31,9 +31,7 @@ describe('createDetermineSharedExternals', () => {
         mockAdapters = {
             versionCheck: createVersionCheck(),
             sharedExternalsRepo: mockSharedExternalsRepository()
-        };
-        mockAdapters.sharedExternalsRepo.getScopes = jest.fn(() => [GLOBAL_SCOPE])
-        
+        };        
         determineSharedExternals = createDetermineSharedExternals(mockConfig, mockAdapters);
     });
 
@@ -69,7 +67,8 @@ describe('createDetermineSharedExternals', () => {
                         host: false,
                         action: "share"
                     }]
-                }
+                },
+                "__GLOBAL__"
             )
         });
 
@@ -153,7 +152,8 @@ describe('createDetermineSharedExternals', () => {
                             action: "skip"
                         },
                     ]
-                }
+                },
+                "__GLOBAL__"
             )
         });
 
@@ -213,7 +213,8 @@ describe('createDetermineSharedExternals', () => {
                             action: "scope"
                         },
                     ]
-                }
+                },
+                "__GLOBAL__"
             )
         });
         
@@ -249,6 +250,80 @@ describe('createDetermineSharedExternals', () => {
 
             await expect(determineSharedExternals()).rejects.toEqual(new NFError("Failed to determine shared externals."));
             
+        });
+    });
+
+    describe('Custom scope', () => {
+        it('should set only available version to share', async () => {
+            mockAdapters.sharedExternalsRepo.getScopes = jest.fn(({includeGlobal} = {includeGlobal: true}) => 
+                includeGlobal ? [GLOBAL_SCOPE, "custom-scope"] : ["custom-scope"]
+            )
+            mockAdapters.sharedExternalsRepo.getAll = jest.fn((sharedScope?: string): SharedScope => {
+                if(sharedScope === GLOBAL_SCOPE) {
+                    return {  "dep-a": {
+                        dirty: true,
+                        versions: [{
+                            version: "1.2.3", 
+                            file: "http://my.service/mfe1/dep-a.js",
+                            requiredVersion: "~1.2.1",
+                            strictVersion: false,
+                            cached: false,
+                            host: false,
+                            action: "skip"
+                        }]
+                    }}
+                }
+                if(sharedScope === "custom-scope") {
+                    return {  "dep-b": {
+                        dirty: true,
+                        versions: [{
+                            version: "4.5.6", 
+                            file: "http://my.service/mfe1/dep-b.js",
+                            requiredVersion: "~4.5.1",
+                            strictVersion: false,
+                            cached: false,
+                            host: false,
+                            action: "skip"
+                        }]
+                    }}
+                }
+                return {};
+            });
+
+            await determineSharedExternals();
+
+            expect(mockAdapters.sharedExternalsRepo.addOrUpdate).toHaveBeenCalledWith(
+                "dep-a", 
+                {
+                    dirty: false,
+                    versions: [{
+                        version: "1.2.3", 
+                        file: "http://my.service/mfe1/dep-a.js",
+                        requiredVersion: "~1.2.1",
+                        strictVersion: false,
+                        cached: false,
+                        host: false,
+                        action: "share"
+                    }]
+                }, "__GLOBAL__"
+            )
+
+            expect(mockAdapters.sharedExternalsRepo.addOrUpdate).toHaveBeenCalledWith(
+                "dep-b", 
+                {
+                    dirty: false,
+                    versions: [{
+                        version: "4.5.6", 
+                        file: "http://my.service/mfe1/dep-b.js",
+                        requiredVersion: "~4.5.1",
+                        strictVersion: false,
+                        cached: false,
+                        host: false,
+                        action: "share"
+                    }]
+                },
+                "custom-scope"
+            )
         });
     });
 

--- a/src/lib/2.app/determine-shared-externals.ts
+++ b/src/lib/2.app/determine-shared-externals.ts
@@ -81,14 +81,13 @@ const createDetermineSharedExternals = (
     }
 
     return () => {
-        for (const sharedScope in ports.sharedExternalsRepo.getScopes()) {
+        for (const sharedScope of ports.sharedExternalsRepo.getScopes()) {
             const sharedExternals = ports.sharedExternalsRepo.getAll(sharedScope);
-
             try {
                 Object.entries(sharedExternals)
                     .filter(([_, e]) => e.dirty)
                     .forEach(([name, external]) => {
-                        ports.sharedExternalsRepo.addOrUpdate(name, updateVersionActions(name, external))
+                        ports.sharedExternalsRepo.addOrUpdate(name, updateVersionActions(name, external), sharedScope)
                     });
 
                 config.log.debug("Processed shared externals", sharedExternals);

--- a/src/lib/2.app/determine-shared-externals.ts
+++ b/src/lib/2.app/determine-shared-externals.ts
@@ -81,22 +81,24 @@ const createDetermineSharedExternals = (
     }
 
     return () => {
-        const sharedExternals = ports.sharedExternalsRepo.getAll();
+        for (const sharedScope in ports.sharedExternalsRepo.getScopes()) {
+            const sharedExternals = ports.sharedExternalsRepo.getAll(sharedScope);
 
-        try {
-            Object.entries(sharedExternals)
-                .filter(([_, e]) => e.dirty)
-                .forEach(([name, external]) => {
-                    ports.sharedExternalsRepo.addOrUpdate(name, updateVersionActions(name, external))
-                });
+            try {
+                Object.entries(sharedExternals)
+                    .filter(([_, e]) => e.dirty)
+                    .forEach(([name, external]) => {
+                        ports.sharedExternalsRepo.addOrUpdate(name, updateVersionActions(name, external))
+                    });
 
-            config.log.debug("Processed shared externals", sharedExternals);
-            return Promise.resolve();
-        } catch(err: unknown) {
-            config.log.error("Failed to determine shared externals", err);
-            config.log.debug("Currently processed shared externals", sharedExternals);
-            return Promise.reject(new NFError("Failed to determine shared externals."));
+                config.log.debug("Processed shared externals", sharedExternals);
+            } catch(err: unknown) {
+                config.log.error("Failed to determine shared externals in scope "+sharedScope, err);
+                config.log.debug("Currently processed shared externals in scope "+sharedScope, sharedExternals);
+                return Promise.reject(new NFError("Failed to determine shared externals."));
+            }
         }
+        return Promise.resolve();
     };
 }
 

--- a/src/lib/2.app/driving-ports/for-shared-externals-storage.port.ts
+++ b/src/lib/2.app/driving-ports/for-shared-externals-storage.port.ts
@@ -1,9 +1,9 @@
-import type { SharedExternal, SharedExternals, SharedVersion } from "lib/1.domain";
+import type { SharedExternal, SharedScope, SharedVersion } from "lib/1.domain";
 import type { Optional } from "lib/utils/optional";
 
 export type ForSharedExternalsStorage = {
-    tryGetVersions: (external: string) => Optional<SharedVersion[]>,
-    getAll: () => SharedExternals,
-    addOrUpdate: (name: string, external: SharedExternal) => ForSharedExternalsStorage,
+    tryGetVersions: (external: string, sharedScope?: string) => Optional<SharedVersion[]>,
+    getAll: (sharedScope?: string) => SharedScope,
+    addOrUpdate: (name: string, external: SharedExternal, sharedScope?: string) => ForSharedExternalsStorage,
     commit: () => ForSharedExternalsStorage
 }

--- a/src/lib/2.app/driving-ports/for-shared-externals-storage.port.ts
+++ b/src/lib/2.app/driving-ports/for-shared-externals-storage.port.ts
@@ -4,6 +4,7 @@ import type { Optional } from "lib/utils/optional";
 export type ForSharedExternalsStorage = {
     tryGetVersions: (external: string, sharedScope?: string) => Optional<SharedVersion[]>,
     getAll: (sharedScope?: string) => SharedScope,
+    getScopes: () => string[],
     addOrUpdate: (name: string, external: SharedExternal, sharedScope?: string) => ForSharedExternalsStorage,
     commit: () => ForSharedExternalsStorage
 }

--- a/src/lib/2.app/driving-ports/for-shared-externals-storage.port.ts
+++ b/src/lib/2.app/driving-ports/for-shared-externals-storage.port.ts
@@ -4,7 +4,7 @@ import type { Optional } from "lib/utils/optional";
 export type ForSharedExternalsStorage = {
     tryGetVersions: (external: string, sharedScope?: string) => Optional<SharedVersion[]>,
     getAll: (sharedScope?: string) => SharedScope,
-    getScopes: () => string[],
+    getScopes: (o?: {includeGlobal:boolean}) => string[],
     addOrUpdate: (name: string, external: SharedExternal, sharedScope?: string) => ForSharedExternalsStorage,
     commit: () => ForSharedExternalsStorage
 }

--- a/src/lib/2.app/expose-module-loader.spec.ts
+++ b/src/lib/2.app/expose-module-loader.spec.ts
@@ -28,9 +28,6 @@ describe('createExposeModuleLoader', () => {
             remoteInfoRepo: mockRemoteInfoRepository(),
             browser: mockBrowser()
         };
-
-        mockAdapters.remoteInfoRepo.getAll = jest.fn(() => ({}));
-
         exposeModuleLoader = createExposeModuleLoader(mockConfig, mockAdapters);
     });
 

--- a/src/lib/2.app/generate-import-map.sharedscope-externals.spec.ts
+++ b/src/lib/2.app/generate-import-map.sharedscope-externals.spec.ts
@@ -1,0 +1,418 @@
+import { ForGeneratingImportMap } from './driver-ports/for-generating-import-map';
+import { DrivingContract } from './driving-ports/driving.contract';
+import { createGenerateImportMap } from './generate-import-map';
+import { mockSharedExternalsRepository } from 'lib/6.mocks/adapters/shared-externals.repository.mock';
+import { mockScopedExternalsRepository } from 'lib/6.mocks/adapters/scoped-externals.repository.mock';
+import { mockRemoteInfoRepository } from 'lib/6.mocks/adapters/remote-info.repository.mock';
+import { LoggingConfig } from './config/log.contract';
+import { ModeConfig } from './config/mode.contract';
+import { GLOBAL_SCOPE, SharedScope } from 'lib/1.domain';
+import { NFError } from 'lib/native-federation.error';
+
+describe('createGenerateImportMap (sharedScope-externals)', () => {
+    let generateImportMap: ForGeneratingImportMap;
+    let mockAdapters: Pick<DrivingContract, 'remoteInfoRepo'|'scopedExternalsRepo'|'sharedExternalsRepo'>;
+    let mockConfig: LoggingConfig & ModeConfig;
+
+    beforeEach(() => {
+        mockConfig = {
+            log: {
+                debug: jest.fn(),
+                warn: jest.fn(),
+                error: jest.fn(),
+                level: "debug"
+            },
+            strict: false,
+            profile: {
+                latestSharedExternal: false,
+                skipCachedRemotes: false
+            }
+        } as LoggingConfig & ModeConfig;
+
+        mockAdapters = {
+            remoteInfoRepo: mockRemoteInfoRepository(),
+            scopedExternalsRepo: mockScopedExternalsRepository(),
+            sharedExternalsRepo: mockSharedExternalsRepository()
+        };
+
+        mockAdapters.remoteInfoRepo.getAll = jest.fn(() => ({}));
+        mockAdapters.scopedExternalsRepo.getAll = jest.fn(() => ({}));
+        mockAdapters.sharedExternalsRepo.getAll = jest.fn(() => ({}));
+        mockAdapters.sharedExternalsRepo.getAll = jest.fn(() => ({}));
+        mockAdapters.sharedExternalsRepo.getScopes = jest.fn(({includeGlobal} = {includeGlobal: true}) => 
+            includeGlobal ? [GLOBAL_SCOPE, "custom-scope"] : ["custom-scope"]
+        )
+
+        generateImportMap = createGenerateImportMap(mockConfig, mockAdapters);
+    });
+
+
+    it('should add the scoped externals to the right scope.', async () => {
+        mockAdapters.sharedExternalsRepo.getAll = jest.fn((scope?: string): SharedScope => {
+            return (!scope || scope === GLOBAL_SCOPE)
+                ? {}
+                : {
+                    "dep-a":{
+                        dirty: false,
+                        versions: [
+                            {
+                                version: "1.2.3", 
+                                file: "http://my.service/mfe1/dep-a.js",
+                                requiredVersion: "~1.2.1",
+                                strictVersion: false,
+                                cached: false,
+                                host: false,
+                                action: "scope"
+                            },
+                            {
+                                version: "1.2.2", 
+                                file: "http://my.service/mfe2/dep-a.js",
+                                requiredVersion: "~1.2.1",
+                                strictVersion: false,
+                                cached: false,
+                                host: true,
+                                action: "scope"
+                            },
+                        ]
+                    }
+                }       
+        })
+
+        const actual = await generateImportMap();
+
+        expect(actual).toEqual({
+            imports: {},
+            scopes: {
+                "http://my.service/mfe1/": {
+                    "dep-a": 'http://my.service/mfe1/dep-a.js'
+                },
+                "http://my.service/mfe2/": {
+                    "dep-a": 'http://my.service/mfe2/dep-a.js'
+                }
+            }
+        })
+    });
+
+    it('should override the skipped externals to the right scope.', async () => {
+        mockAdapters.sharedExternalsRepo.getAll = jest.fn((scope?: string): SharedScope => {
+            return (!scope || scope === GLOBAL_SCOPE)
+                ? {}
+                : {
+                    "dep-a":{
+                        dirty: false,
+                        versions: [
+                            {
+                                version: "1.2.3", 
+                                file: "http://my.service/mfe1/dep-a.js",
+                                requiredVersion: "~1.2.1",
+                                strictVersion: false,
+                                cached: false,
+                                host: false,
+                                action: "share"
+                            },
+                            {
+                                version: "1.2.2", 
+                                file: "http://my.service/mfe2/dep-a.js",
+                                requiredVersion: "~1.2.1",
+                                strictVersion: false,
+                                cached: false,
+                                host: true,
+                                action: "skip"
+                            }
+                        ]
+                    }
+                }       
+        })
+
+        const actual = await generateImportMap();
+
+        expect(actual).toEqual({
+            imports: {},
+            scopes: {
+                "http://my.service/mfe1/": {
+                    "dep-a": 'http://my.service/mfe1/dep-a.js'
+                },
+                "http://my.service/mfe2/": {
+                    "dep-a": 'http://my.service/mfe1/dep-a.js'
+                }
+            }
+        })
+    });
+
+    it('should not override a scoped version.', async () => {
+        mockAdapters.sharedExternalsRepo.getAll = jest.fn((scope?: string): SharedScope => {
+            return (!scope || scope === GLOBAL_SCOPE)
+                ? {}
+                : {
+                    "dep-a":{
+                        dirty: false,
+                        versions: [
+                            {
+                                version: "1.2.3", 
+                                file: "http://my.service/mfe1/dep-a.js",
+                                requiredVersion: "~1.2.1",
+                                strictVersion: false,
+                                cached: false,
+                                host: false,
+                                action: "share"
+                            },
+                            {
+                                version: "1.2.2", 
+                                file: "http://my.service/mfe2/dep-a.js",
+                                requiredVersion: "~1.2.1",
+                                strictVersion: false,
+                                cached: false,
+                                host: true,
+                                action: "skip"
+                            },
+                            {
+                                version: "1.2.1", 
+                                file: "http://my.service/mfe3/dep-a.js",
+                                requiredVersion: "~1.2.1",
+                                strictVersion: false,
+                                cached: false,
+                                host: false,
+                                action: "scope"
+                            },
+                        ]
+                    }
+                }       
+        })
+
+        const actual = await generateImportMap();
+
+        expect(actual).toEqual({
+            imports: {},
+            scopes: {
+                "http://my.service/mfe1/": {
+                    "dep-a": 'http://my.service/mfe1/dep-a.js'
+                },
+                "http://my.service/mfe2/": {
+                    "dep-a": 'http://my.service/mfe1/dep-a.js'
+                },
+                "http://my.service/mfe3/": {
+                    "dep-a": 'http://my.service/mfe3/dep-a.js'
+                }
+            }
+        })
+    });
+
+    it('should mark the used versions as cached.', async () => {
+        mockAdapters.sharedExternalsRepo.getAll = jest.fn((scope?: string): SharedScope => {
+            return (!scope || scope === GLOBAL_SCOPE)
+                ? {}
+                : {
+                    "dep-a":{
+                        dirty: false,
+                        versions: [
+                            {
+                                version: "1.2.3", 
+                                file: "http://my.service/mfe1/dep-a.js",
+                                requiredVersion: "~1.2.1",
+                                strictVersion: false,
+                                cached: false,
+                                host: false,
+                                action: "share"
+                            },
+                            {
+                                version: "1.2.2", 
+                                file: "http://my.service/mfe2/dep-a.js",
+                                requiredVersion: "~1.2.1",
+                                strictVersion: false,
+                                cached: false,
+                                host: true,
+                                action: "skip"
+                            },
+                            {
+                                version: "1.2.1", 
+                                file: "http://my.service/mfe3/dep-a.js",
+                                requiredVersion: "~1.2.1",
+                                strictVersion: false,
+                                cached: false,
+                                host: false,
+                                action: "scope"
+                            },
+                        ]
+                    }
+                }       
+        })
+
+        await generateImportMap();
+
+        expect(mockAdapters.sharedExternalsRepo.addOrUpdate).toHaveBeenCalledWith(
+            "dep-a",
+            {
+                dirty: false,
+                versions: [
+                    {
+                        version: "1.2.3", 
+                        file: "http://my.service/mfe1/dep-a.js",
+                        requiredVersion: "~1.2.1",
+                        strictVersion: false,
+                        cached: true,
+                        host: false,
+                        action: "share"
+                    },
+                    {
+                        version: "1.2.2", 
+                        file: "http://my.service/mfe2/dep-a.js",
+                        requiredVersion: "~1.2.1",
+                        strictVersion: false,
+                        cached: false,
+                        host: true,
+                        action: "skip"
+                    },
+                    {
+                        version: "1.2.1", 
+                        file: "http://my.service/mfe3/dep-a.js",
+                        requiredVersion: "~1.2.1",
+                        strictVersion: false,
+                        cached: true,
+                        host: false,
+                        action: "scope"
+                    },
+                ]
+            },
+            "custom-scope"
+        )
+    });
+
+    it('should warn the user about 2 shared versions and choose the most recent one if in non-strict mode.', async () => {
+        mockConfig.strict = false;
+
+        mockAdapters.sharedExternalsRepo.getAll = jest.fn((scope?: string): SharedScope => {
+            return (!scope || scope === GLOBAL_SCOPE)
+                ? {}
+                : {
+                    "dep-a":{
+                        dirty: false,
+                        versions: [
+                            {
+                                version: "1.2.3", 
+                                file: "http://my.service/mfe1/dep-a.js",
+                                requiredVersion: "~1.2.1",
+                                strictVersion: false,
+                                cached: false,
+                                host: false,
+                                action: "share"
+                            },
+                            {
+                                version: "1.2.2", 
+                                file: "http://my.service/mfe2/dep-a.js",
+                                requiredVersion: "~1.2.1",
+                                strictVersion: false,
+                                cached: false,
+                                host: true,
+                                action: "share"
+                            }
+                        ]
+                    }
+                }       
+        })
+
+        const actual = await generateImportMap();
+
+        expect(actual).toEqual({
+            imports: {},
+            scopes: {
+                "http://my.service/mfe1/": {
+                    "dep-a": 'http://my.service/mfe1/dep-a.js'
+                },
+                "http://my.service/mfe2/": {
+                    "dep-a": 'http://my.service/mfe1/dep-a.js'
+                }
+            }
+        });
+        expect(mockConfig.log.warn).toHaveBeenCalledWith("ShareScope external custom-scope.dep-a has multiple shared versions.")
+
+    });
+
+    
+    it('should throw error if 2 shared versions and in strict mode.', async () => {
+        mockConfig.strict = true;
+
+        mockAdapters.sharedExternalsRepo.getAll = jest.fn((scope?: string): SharedScope => {
+            return (!scope || scope === GLOBAL_SCOPE)
+                ? {}
+                : {
+                    "dep-a":{
+                        dirty: false,
+                        versions: [
+                            {
+                                version: "1.2.3", 
+                                file: "http://my.service/mfe1/dep-a.js",
+                                requiredVersion: "~1.2.1",
+                                strictVersion: false,
+                                cached: false,
+                                host: false,
+                                action: "share"
+                            },
+                            {
+                                version: "1.2.2", 
+                                file: "http://my.service/mfe2/dep-a.js",
+                                requiredVersion: "~1.2.1",
+                                strictVersion: false,
+                                cached: false,
+                                host: true,
+                                action: "share"
+                            }
+                        ]
+                    }
+                }       
+        })
+
+        await expect(generateImportMap()).rejects.toEqual(new NFError("Could not create ImportMap."));
+        expect(mockConfig.log.error).toHaveBeenCalledWith("ShareScope external custom-scope.dep-a has multiple shared versions.")
+    });
+    
+    it('should warn the user about 0 shared versions and scope all if in non-strict mode.', async () => {
+        mockConfig.strict = false;
+
+        mockAdapters.sharedExternalsRepo.getAll = jest.fn((scope?: string): SharedScope => {
+            return (!scope || scope === GLOBAL_SCOPE)
+                ? {}
+                : {
+                    "dep-a":{
+                        dirty: false,
+                        versions: [
+                            {
+                                version: "1.2.3", 
+                                file: "http://my.service/mfe1/dep-a.js",
+                                requiredVersion: "~1.2.1",
+                                strictVersion: false,
+                                cached: false,
+                                host: false,
+                                action: "skip"
+                            },
+                            {
+                                version: "1.2.2", 
+                                file: "http://my.service/mfe2/dep-a.js",
+                                requiredVersion: "~1.2.1",
+                                strictVersion: false,
+                                cached: false,
+                                host: true,
+                                action: "skip"
+                            }
+                        ]
+                    }
+                }       
+        })
+
+        const actual = await generateImportMap();
+
+        expect(actual).toEqual({
+            imports: {},
+            scopes: {
+                "http://my.service/mfe1/": {
+                    "dep-a": 'http://my.service/mfe1/dep-a.js'
+                },
+                "http://my.service/mfe2/": {
+                    "dep-a": 'http://my.service/mfe2/dep-a.js'
+                }
+            }
+        });
+        expect(mockConfig.log.warn).toHaveBeenCalledWith("ShareScope external custom-scope.dep-a has no shared versions.")
+
+    });
+
+});

--- a/src/lib/2.app/generate-import-map.ts
+++ b/src/lib/2.app/generate-import-map.ts
@@ -5,7 +5,7 @@ import * as _path from "lib/utils/path";
 import { NFError } from "lib/native-federation.error";
 import type { LoggingConfig } from "./config/log.contract";
 import type { ModeConfig } from "./config/mode.contract";
-import { type SharedVersion } from "lib/1.domain";
+import { GLOBAL_SCOPE, type SharedExternal, type SharedVersion } from "lib/1.domain";
 
 
 /**
@@ -77,7 +77,7 @@ const createGenerateImportMap = (
         return importMap;
     }
 
-    function addSharedExternals(importMap: ImportMap) {
+    function addGlobalSharedExternals(importMap: ImportMap) {
         const sharedExternals = ports.sharedExternalsRepo.getAll();
 
         Object.entries(sharedExternals).forEach(([externalName, external]) => {
@@ -88,11 +88,54 @@ const createGenerateImportMap = (
         return importMap;
     }
 
+    const findOverride = (external: SharedExternal, scope: string, externalName: string): SharedVersion|undefined => {
+        const sharedVersions = external.versions.filter(v => v.action === "share");
+        if(sharedVersions.length > 1) {
+            config.log.error(`ShareScope external ${scope}.${externalName} has multiple shared versions.`);
+            throw new NFError("Could not create ImportMap.");
+        }
+        if(sharedVersions.length < 1) {
+            config.log.warn(`Singleton external ${scope}.${externalName} has no shared versions.`);
+        }
+        return sharedVersions[0];
+    }
+
+    const addOrOverrideSkippedVersions = (externalName: string, override?: SharedVersion) => (importMap: ImportMap, version: SharedVersion) => {
+        
+        let scope = _path.getScope(version.file);
+
+        if(!!override && version.action === "skip") {
+            scope = _path.getScope(override.file);
+        }
+
+        if(!importMap.scopes) importMap.scopes = {};
+        if(!importMap.scopes[scope]) importMap.scopes[scope] = {};
+        importMap.scopes[scope]![externalName] = version.file;
+        version.cached = true;
+        return importMap;
+    }
+
+    function addSharedScopeExternals(importMap: ImportMap) {
+        ports.sharedExternalsRepo.getScopes()
+            .filter(s => s !== GLOBAL_SCOPE) 
+            .forEach(sharedScope => {
+                const sharedExternals = ports.sharedExternalsRepo.getAll(sharedScope);
+                Object.entries(sharedExternals).forEach(([externalName, external]) => {
+                    const override = findOverride(external, sharedScope, externalName);
+                    importMap = external.versions.reduce(addOrOverrideSkippedVersions(externalName, override), importMap);
+                    ports.sharedExternalsRepo.addOrUpdate(externalName, external);
+                });
+            })
+
+        return importMap;
+    }
+
     return () => {
         return Promise.resolve({imports: {}})
             .then(addRemoteInfos)
             .then(addScopedExternals)
-            .then(addSharedExternals);
+            .then(addSharedScopeExternals)
+            .then(addGlobalSharedExternals);
     };
 }
 

--- a/src/lib/2.app/generate-import-map.ts
+++ b/src/lib/2.app/generate-import-map.ts
@@ -5,7 +5,7 @@ import * as _path from "lib/utils/path";
 import { NFError } from "lib/native-federation.error";
 import type { LoggingConfig } from "./config/log.contract";
 import type { ModeConfig } from "./config/mode.contract";
-import type { SharedVersion } from "lib/1.domain";
+import { type SharedVersion } from "lib/1.domain";
 
 
 /**

--- a/src/lib/2.app/generate-import-map.ts
+++ b/src/lib/2.app/generate-import-map.ts
@@ -5,7 +5,7 @@ import * as _path from "lib/utils/path";
 import { NFError } from "lib/native-federation.error";
 import type { LoggingConfig } from "./config/log.contract";
 import type { ModeConfig } from "./config/mode.contract";
-import { GLOBAL_SCOPE, type SharedExternal, type SharedVersion } from "lib/1.domain";
+import type { SharedExternal, SharedVersion } from "lib/1.domain";
 
 
 /**
@@ -116,8 +116,7 @@ const createGenerateImportMap = (
     }
 
     function addSharedScopeExternals(importMap: ImportMap) {
-        ports.sharedExternalsRepo.getScopes()
-            .filter(s => s !== GLOBAL_SCOPE) 
+        ports.sharedExternalsRepo.getScopes({includeGlobal: false})
             .forEach(sharedScope => {
                 const sharedExternals = ports.sharedExternalsRepo.getAll(sharedScope);
                 Object.entries(sharedExternals).forEach(([externalName, external]) => {

--- a/src/lib/2.app/process-remote-entries.spec.ts
+++ b/src/lib/2.app/process-remote-entries.spec.ts
@@ -163,8 +163,7 @@ describe('createProcessRemoteEntries', () => {
                             action: "skip"
                         } as SharedVersion
                     ]
-
-                }
+                }, undefined
             );
         });
 
@@ -193,6 +192,53 @@ describe('createProcessRemoteEntries', () => {
             expect(mockAdapters.scopedExternalsRepo.addExternal).not.toHaveBeenCalled();
             expect(mockConfig.log.warn).toHaveBeenCalledWith("[team/mfe1][dep-a] Version 'bad-version' is not a valid version, skipping version.")
 
+        });
+        
+    });
+
+    describe('process shared externals - handle custom scopes', () => {
+        it('should add a shared external', async () => {
+            mockAdapters.sharedExternalsRepo.tryGetVersions = jest.fn((): Optional<SharedVersion[]> => Optional.empty())
+            const remoteEntries = [
+                {
+                    name: 'team/mfe1',
+                    url: "http://my.service/mfe1/remoteEntry.json",
+                    exposes: [],
+                    shared: [
+                        {
+                            version: "1.2.3", 
+                            requiredVersion: "~1.2.1", 
+                            strictVersion: false,
+                            sharedScope: "custom-scope",
+                            singleton: true,
+                            packageName: "dep-a",
+                            outFileName: "dep-a.js"
+                        }
+                    ]
+                }
+            ];
+
+            await processRemoteEntries(remoteEntries);
+
+            expect(mockAdapters.sharedExternalsRepo.addOrUpdate).toHaveBeenCalledTimes(1);
+            expect(mockAdapters.sharedExternalsRepo.addOrUpdate).toHaveBeenCalledWith(
+                'dep-a',
+                {
+                    dirty: true,
+                    versions: [
+                        {
+                            version: "1.2.3", 
+                            file: "http://my.service/mfe1/dep-a.js",
+                            requiredVersion: "~1.2.1",
+                            strictVersion: false,
+                            cached: false,
+                            host: false,
+                            action: "skip"
+                        } as SharedVersion
+                    ]
+                },
+                "custom-scope"
+            );
         });
         
     });
@@ -286,8 +332,8 @@ describe('createProcessRemoteEntries', () => {
                             action: "skip"
                         } as SharedVersion
                     ]
-
-                }
+                }, 
+                undefined
             );
         });
 
@@ -411,7 +457,7 @@ describe('createProcessRemoteEntries', () => {
                         } 
                     ]
 
-                }
+                }, undefined
             );
         });
     });

--- a/src/lib/2.app/process-remote-entries.ts
+++ b/src/lib/2.app/process-remote-entries.ts
@@ -82,7 +82,8 @@ const createProcessRemoteEntries = (
 
             ports.sharedExternalsRepo.addOrUpdate(
                 sharedInfo.packageName, 
-                { dirty: true, versions: cached.sort((a,b) => ports.versionCheck.compare(b.version, a.version)) }
+                { dirty: true, versions: cached.sort((a,b) => ports.versionCheck.compare(b.version, a.version)) },
+                sharedInfo.sharedScope
             );
         }
 

--- a/src/lib/2.app/process-remote-entries.ts
+++ b/src/lib/2.app/process-remote-entries.ts
@@ -56,7 +56,7 @@ const createProcessRemoteEntries = (
     function addSharedExternal(scope: string, sharedInfo: SharedInfo, isHostVersion?: boolean) 
         : void {
             const cached: SharedVersion[] = ports.sharedExternalsRepo
-                .tryGetVersions(sharedInfo.packageName)
+                .tryGetVersions(sharedInfo.packageName, sharedInfo.sharedScope)
                 .orElse([]);
 
             const matchingVersionIDX = cached.findIndex(c => c.version === sharedInfo.version);

--- a/src/lib/3.adapters/storage/shared-externals.repository.spec.ts
+++ b/src/lib/3.adapters/storage/shared-externals.repository.spec.ts
@@ -335,7 +335,6 @@ describe('createSharedExternalsRepository', () => {
                 [GLOBAL_SCOPE]: {},
                 "custom-scope": {},
                 "other-custom-scope": {}
-
             });
             
             const actual = externalsRepo.getScopes({includeGlobal: false});

--- a/src/lib/3.adapters/storage/shared-externals.repository.ts
+++ b/src/lib/3.adapters/storage/shared-externals.repository.ts
@@ -1,4 +1,4 @@
-import type { SharedExternal, SharedExternals } from "lib/1.domain/externals/external.contract";
+import { type SharedExternal, type SharedExternals, GLOBAL_SCOPE } from "lib/1.domain/externals/external.contract";
 import type { StorageConfig, StorageEntry } from "lib/2.app/config/storage.contract";
 import type { ForSharedExternalsStorage } from "lib/2.app/driving-ports/for-shared-externals-storage.port";
 import { Optional } from "lib/utils/optional";
@@ -6,22 +6,23 @@ import { Optional } from "lib/utils/optional";
 const createSharedExternalsRepository = (
     config: StorageConfig,
 ): ForSharedExternalsStorage => {
-    const STORAGE: StorageEntry<SharedExternals> = config.storage("shared-externals", {});
+    const STORAGE: StorageEntry<SharedExternals> = config.storage<SharedExternals>("shared-externals", {[GLOBAL_SCOPE]: {}});
 
     if (config.clearStorage) STORAGE.clear();
 
     const _cache: SharedExternals = STORAGE.get()!;
 
     return {
-        getAll: function () {
-            return {..._cache};
+        getAll: function (sharedScope?: string) {
+            return {..._cache[sharedScope ?? GLOBAL_SCOPE]};
         },
-        addOrUpdate: function (externalName: string, external: SharedExternal) {
-            _cache[externalName] = external;
+        addOrUpdate: function (externalName: string, external: SharedExternal, sharedScope?: string) {
+            if(!_cache[sharedScope ?? GLOBAL_SCOPE]) _cache[sharedScope ?? GLOBAL_SCOPE] = {};
+            _cache[sharedScope ?? GLOBAL_SCOPE]![externalName] = external;
             return this;
         },
-        tryGetVersions: function (external: string) {
-            return Optional.of(_cache[external]?.versions);
+        tryGetVersions: function (external: string, sharedScope?: string) {
+            return Optional.of(_cache[sharedScope ?? GLOBAL_SCOPE]?.[external]?.versions);
         },
         commit: function () {
             STORAGE.set(_cache);

--- a/src/lib/3.adapters/storage/shared-externals.repository.ts
+++ b/src/lib/3.adapters/storage/shared-externals.repository.ts
@@ -21,8 +21,9 @@ const createSharedExternalsRepository = (
             _cache[sharedScope ?? GLOBAL_SCOPE]![externalName] = external;
             return this;
         },
-        getScopes: function() {
-            return Object.keys(_cache);
+        getScopes: function(o = {includeGlobal: true}) {
+            if (o.includeGlobal) return Object.keys(_cache);
+            return Object.keys(_cache).filter(s => s !== GLOBAL_SCOPE);
         },
         tryGetVersions: function (external: string, sharedScope?: string) {
             return Optional.of(_cache[sharedScope ?? GLOBAL_SCOPE]?.[external]?.versions);

--- a/src/lib/3.adapters/storage/shared-externals.repository.ts
+++ b/src/lib/3.adapters/storage/shared-externals.repository.ts
@@ -21,6 +21,9 @@ const createSharedExternalsRepository = (
             _cache[sharedScope ?? GLOBAL_SCOPE]![externalName] = external;
             return this;
         },
+        getScopes: function() {
+            return Object.keys(_cache);
+        },
         tryGetVersions: function (external: string, sharedScope?: string) {
             return Optional.of(_cache[sharedScope ?? GLOBAL_SCOPE]?.[external]?.versions);
         },

--- a/src/lib/6.mocks/adapters/shared-externals.repository.mock.ts
+++ b/src/lib/6.mocks/adapters/shared-externals.repository.mock.ts
@@ -6,6 +6,6 @@ export const mockSharedExternalsRepository = ()
         addOrUpdate: jest.fn(),
         getAll: jest.fn(),
         commit: jest.fn(),
-        getScopes: jest.fn(() => [GLOBAL_SCOPE]),
+        getScopes: jest.fn((o = {includeGlobal: true}) => o.includeGlobal ? [GLOBAL_SCOPE] : []),
         tryGetVersions: jest.fn()
     });

--- a/src/lib/6.mocks/adapters/shared-externals.repository.mock.ts
+++ b/src/lib/6.mocks/adapters/shared-externals.repository.mock.ts
@@ -5,5 +5,6 @@ export const mockSharedExternalsRepository = ()
         addOrUpdate: jest.fn(),
         getAll: jest.fn(),
         commit: jest.fn(),
+        getScopes: jest.fn(),
         tryGetVersions: jest.fn()
     });

--- a/src/lib/6.mocks/adapters/shared-externals.repository.mock.ts
+++ b/src/lib/6.mocks/adapters/shared-externals.repository.mock.ts
@@ -1,3 +1,4 @@
+import { GLOBAL_SCOPE } from "lib/1.domain";
 import { ForSharedExternalsStorage } from "lib/2.app/driving-ports/for-shared-externals-storage.port";
 
 export const mockSharedExternalsRepository = ()
@@ -5,6 +6,6 @@ export const mockSharedExternalsRepository = ()
         addOrUpdate: jest.fn(),
         getAll: jest.fn(),
         commit: jest.fn(),
-        getScopes: jest.fn(),
+        getScopes: jest.fn(() => [GLOBAL_SCOPE]),
         tryGetVersions: jest.fn()
     });

--- a/src/lib/6.mocks/adapters/shared-externals.repository.mock.ts
+++ b/src/lib/6.mocks/adapters/shared-externals.repository.mock.ts
@@ -6,6 +6,6 @@ export const mockSharedExternalsRepository = ()
         addOrUpdate: jest.fn(),
         getAll: jest.fn(),
         commit: jest.fn(),
-        getScopes: jest.fn((o = {includeGlobal: true}) => o.includeGlobal ? [GLOBAL_SCOPE] : []),
+        getScopes: jest.fn((o = {includeGlobal: true}) => (o.includeGlobal) ? [GLOBAL_SCOPE] : []),
         tryGetVersions: jest.fn()
     });

--- a/src/lib/6.mocks/domain/externals/external.mock.ts
+++ b/src/lib/6.mocks/domain/externals/external.mock.ts
@@ -1,4 +1,4 @@
-import { ExternalsScope, SharedExternal, SharedExternals } from "lib/1.domain";
+import { ExternalsScope, GLOBAL_SCOPE, SharedExternal, SharedExternals } from "lib/1.domain";
 import { MOCK_VERSION_I, MOCK_VERSION_II, MOCK_VERSION_III, MOCK_VERSION_IV, MOCK_VERSION_V, MOCK_VERSION_VI } from "./version.mock";
 
 /**
@@ -36,7 +36,9 @@ export const MOCK_SHARED_EXTERNAL_III = ()
 
 export const MOCK_SHARED_EXTERNALS = ()
     : SharedExternals => ({
-        "dep-b": MOCK_SHARED_EXTERNAL_I(),
-        "dep-c": MOCK_SHARED_EXTERNAL_II(),
-        "dep-d": MOCK_SHARED_EXTERNAL_III()
+        [GLOBAL_SCOPE]: {
+            "dep-b": MOCK_SHARED_EXTERNAL_I(),
+            "dep-c": MOCK_SHARED_EXTERNAL_II(),
+            "dep-d": MOCK_SHARED_EXTERNAL_III()
+        }
     })


### PR DESCRIPTION
## Motivation

Based on [this request](https://github.com/angular-architects/module-federation-plugin/issues/844#issuecomment-2938887669) in the official module-federation-plugin repository, this allows the user to scope externals  to a specific scope to be able to provide efficient support for legacy micro frontends. 

Based on the [sharedScope](https://module-federation.io/configure/shared.html) implemented in module federation. 