### PR TITLE
fix(88): Added to build.js that paths should be resolved to relative

### DIFF
--- a/build.js
+++ b/build.js
@@ -146,7 +146,6 @@ async function generateTypes() {
     execSync(`tsc -p ${PATHS.tsconfigTypes}`, { stdio: 'inherit' });
     logger.success('Types generated');
     
-    // Post-process declaration files to fix lib/ imports
     await fixDeclarationImports();
     
     return true;
@@ -158,42 +157,74 @@ async function generateTypes() {
 async function fixDeclarationImports() {
   logger.info('Fixing declaration file imports...');
   
-  const glob = require('util').promisify(require('child_process').exec);
-  
   try {
-    // Find all .d.ts files in the dist/types directory
-    const { stdout } = await glob('find dist/types -name "*.d.ts"');
-    const files = stdout.trim().split('\n').filter(f => f);
-    
-    for (const filePath of files) {
-      try {
-        const content = await fs.readFile(filePath, 'utf8');
-        
-        // Replace lib/ imports with relative imports
-        const updatedContent = content.replace(
-          /from ['"]lib\//g,
-          (match, ...args) => {
-            // Calculate relative path from current file to lib directory
-            const relativePath = path.relative(
-              path.dirname(filePath), 
-              path.join('dist/types/lib')
-            );
-            return `from '${relativePath}/`;
-          }
-        );
-        
-        if (content !== updatedContent) {
-          await fs.writeFile(filePath, updatedContent, 'utf8');
-        }
-      } catch (err) {
-        logger.warn(`Could not process ${filePath}: ${err.message}`);
-      }
-    }
-    
+    await processDirectory(path.join('dist', 'types'));
     logger.success('Declaration imports fixed');
   } catch (err) {
     logger.warn(`Could not fix declaration imports: ${err.message}`);
   }
+}
+
+async function processDirectory(dirPath) {
+  const entries = await fs.readdir(dirPath, { withFileTypes: true });
+  
+  for (const entry of entries) {
+    const fullPath = path.join(dirPath, entry.name);
+    
+    if (entry.isDirectory()) {
+      await processDirectory(fullPath);
+    } else if (entry.isFile() && entry.name.endsWith('.d.ts')) {
+      await fixImportsInFile(fullPath);
+    }
+  }
+}
+
+async function fixImportsInFile(filePath) {
+  try {
+    const content = await fs.readFile(filePath, 'utf8');
+    
+    const importRegex = /(?:from\s+['"`])(lib\/[^'"`\s]+)(?:['"`])/g;
+    const exportRegex = /(?:export\s+.*?\s+from\s+['"`])(lib\/[^'"`\s]+)(?:['"`])/g;
+    
+    let updatedContent = content;
+    let hasChanges = false;
+    
+    updatedContent = updatedContent.replace(importRegex, (match, libPath) => {
+      const relativePath = convertLibPathToRelative(filePath, libPath);
+      hasChanges = true;
+      return match.replace(libPath, relativePath);
+    });
+    
+    updatedContent = updatedContent.replace(exportRegex, (match, libPath) => {
+      const relativePath = convertLibPathToRelative(filePath, libPath);
+      hasChanges = true;
+      return match.replace(libPath, relativePath);
+    });
+    
+    if (hasChanges) {
+      await fs.writeFile(filePath, updatedContent, 'utf8');
+    }
+  } catch (err) {
+    logger.warn(`Could not process ${filePath}: ${err.message}`);
+  }
+}
+
+function convertLibPathToRelative(declarationFilePath, libPath) {
+  const pathWithoutLib = libPath.replace(/^lib\//, '');
+  
+  const declarationDir = path.dirname(declarationFilePath);
+  
+  const targetPath = path.join('dist', 'types', 'lib', pathWithoutLib);
+  
+  let relativePath = path.relative(declarationDir, targetPath);
+  
+  relativePath = relativePath.replace(/\\/g, '/');
+  
+  if (!relativePath.startsWith('.') && !relativePath.startsWith('/')) {
+    relativePath = './' + relativePath;
+  }
+  
+  return relativePath;
 }
 
 async function updatePackageJson() {

--- a/src/lib/2.app/config/config.contract.ts
+++ b/src/lib/2.app/config/config.contract.ts
@@ -1,4 +1,4 @@
-import type { LoggingConfig, LoggingOptions } from 'lib/2.app/config/log.contract';
+import type { LoggingConfig, LoggingOptions } from './log.contract';
 import type { StorageConfig, StorageOptions } from './storage.contract';
 import type { ImportMapConfig, ImportMapOptions } from './import-map.contract';
 import type { HostConfig, HostOptions } from './host.contract';

--- a/src/lib/init-federation.contract.ts
+++ b/src/lib/init-federation.contract.ts
@@ -1,5 +1,5 @@
-import type { ConfigContract } from 'lib/2.app/config';
-import type { DrivingContract } from 'lib/2.app/driving-ports/driving.contract';
+import type { ConfigContract } from './2.app/config';
+import type { DrivingContract } from './2.app/driving-ports/driving.contract';
 
 export type LoadRemoteModule<TModule = unknown> = (
   remoteName: string,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,9 @@
     "moduleResolution": "Bundler",    
     "rootDir": "./src",
     "baseUrl": "./src",
+    "paths": {
+      "lib/*": ["./lib/*"]
+    },
     
     "strict": true,
     "useUnknownInCatchVariables": true,


### PR DESCRIPTION
Closes #88.

## Changes:

Exported types are now all relative paths:

```
import type { Logger } from 'lib/2.app/config/log.contract';
declare const consoleLogger: Logger;
export { consoleLogger };
```

becomes

```
import type { Logger } from '../../2.app/config/log.contract';
declare const consoleLogger: Logger;
export { consoleLogger };
```