### PR TITLE
feat(90): Added audit section

### DIFF
--- a/build.js
+++ b/build.js
@@ -96,6 +96,14 @@ async function generateBundles() {
       sourcemap: true
     },
 
+    'vanilla-native-federation/audit': {
+      ...baseConfig,
+      entryPoints: ['src/lib/audit.index.ts'],
+      outfile: path.join(OUTPUT_PATHS.fesm2022, 'audit.mjs'),
+      bundle: true,
+      sourcemap: true
+    },
+
     'quickstart': {
       ...baseConfig,
       entryPoints: [path.join(PATHS.quickstart, "quickstart.ts")],
@@ -103,7 +111,8 @@ async function generateBundles() {
       bundle: true,
       sourcemap: false,
       minify: true
-    }
+    },
+
   };
 
   return builds;
@@ -130,6 +139,11 @@ function generatePackageExports() {
       "./options": {
         "types": "./types/lib/options.index.d.ts",
         "default": "./fesm2022/options.mjs"
+      },
+
+      "./audit": {
+        "types": "./types/lib/audit.index.d.ts",
+        "default": "./fesm2022/audit.mjs"
       }
     },
     

--- a/docs/config.md
+++ b/docs/config.md
@@ -121,16 +121,38 @@ The mode config focusses on the way the library behaves, especially when resolvi
 
 ```javascript
 export type ModeOptions = {
-    strict?: boolean,
-    profile?: ModeProfileConfig
-}
+  strict?: boolean | {
+    strictRemoteEntry?: boolean;
+    strictExternalCompatibility?: boolean;
+    strictExternalVersion?: boolean;
+    strictImportMap?: boolean;
+  };
+  profile?: {
+    latestSharedExternal?: boolean;
+    overrideCachedRemotes?: 'always' | 'never' | 'init-only';
+    overrideCachedRemotesIfURLMatches?: boolean;
+  };
+};
 ```
 
 ### Options:
 
+The strictness part will define how the orchestrator behaves when an unexpected or erronous situation occurs. The profile focusses on how aggressive the orchestrator should handle caching.
+
+#### Strictness
+
+| Option                             | Default | Description                                                                                                                                                                                       |
+| ---------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| strict                             | `false` | When true, the init function will throw an error if anything goes wrong during initialization                                                                                                     |
+| strict.strictRemoteEntry           | `false` | Will throw an error if anything is wrong with a fetched remoteEntry.json. When false, the remote will be skipped if something goes wrong.                                                         |
+| strict.strictExternalCompatibility | `false` | Will throw an error if any of the shared externals are incompatible with other shared external versions. If the value is false, the external will be set to "scoped" instead of "shared".         |
+| strict.strictExternalVersion       | `false` | Will throw an error if the version of an external is not valid semver or missing. If the value is set to false, the 1st version that matches the requiredVersion range of the external is chosen. |
+| strict.strictImportMap             | `false` | Will throw an error if anything goes wrong during the buildup of the importMap. (If something is wrong with the cached externals or the cache is corrupt).                                        |
+
+#### Profiles
+
 | Option                                    | Default     | Description                                                                                                                                                                                                                                                                         |
 | ----------------------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| strict                                    | `false`     | When enabled, the init function will throw an error if a remoteEntry could not be fetched or a version incompatibility within a shared external occurs.                                                                                                                             |
 | profile.latestSharedExternal              | `false`     | When enabled, the version resolver will prioritize using the latest version of a shared external over the most optimal version.                                                                                                                                                     |
 | profile.overrideCachedRemotes             | `init-only` | When enabled, the library will override the cached remotes. The default behavior is to check if the remoteName is in the cache and the remoteEntry url differs from cached remoteEntry url (scopeUrl + "remoteEntry.json) . Available options are `never`, `init-only` and `always` |
 | profile.overrideCachedRemotesIfURLMatches | `false`     | When enabled, the library will override the cached remote, even if the remoteName already exists in cache and the remoteEntry.json URL matches the cached remoteEntry.json url.                                                                                                     |
@@ -142,7 +164,7 @@ import { initFederation } from 'vanilla-native-federation';
 import { defaultProfile, cachingProfile } from 'vanilla-native-federation/options';
 
 initFederation('http://example.org/manifest.json', {
-  strict: true,
+  strict: true, // All settings to strict: true
   profile: cachingProfile, // { latestSharedExternal: false, overrideCachedRemotes: 'never', overrideCachedRemotesIfURLMatches: false }
 });
 ```

--- a/src/lib/2.app/config/mode.contract.ts
+++ b/src/lib/2.app/config/mode.contract.ts
@@ -4,9 +4,20 @@ export type ModeProfileConfig = {
   overrideCachedRemotes: 'always' | 'never' | 'init-only';
   overrideCachedRemotesIfURLMatches: boolean;
 };
+
+export type ModeStrictnessConfig = {
+  strictRemoteEntry: boolean;
+  strictExternalCompatibility: boolean;
+  strictExternalVersion: boolean;
+  strictImportMap: boolean;
+};
+
 export type ModeConfig = {
-  strict: boolean;
+  strict: ModeStrictnessConfig;
   profile: ModeProfileConfig;
 };
 
-export type ModeOptions = Partial<ModeConfig>;
+export type ModeOptions = {
+  strict?: Partial<ModeStrictnessConfig> | boolean;
+  profile?: Partial<ModeProfileConfig>;
+};

--- a/src/lib/2.app/driver-ports/audit/for-auditing-externals.port.ts
+++ b/src/lib/2.app/driver-ports/audit/for-auditing-externals.port.ts
@@ -1,0 +1,6 @@
+import type { RemoteEntry } from 'lib/1.domain';
+
+export type ForConvertingToImportMap = (
+  remoteEntry: RemoteEntry,
+  strictVersion: boolean
+) => Promise<void>;

--- a/src/lib/2.app/driver-ports/audit/for-auditing-externals.port.ts
+++ b/src/lib/2.app/driver-ports/audit/for-auditing-externals.port.ts
@@ -1,6 +1,3 @@
 import type { RemoteEntry } from 'lib/1.domain';
 
-export type ForConvertingToImportMap = (
-  remoteEntry: RemoteEntry,
-  strictVersion: boolean
-) => Promise<void>;
+export type ForAuditingExternals = (remoteEntry: RemoteEntry) => Promise<void>;

--- a/src/lib/2.app/driver-ports/audit/index.ts
+++ b/src/lib/2.app/driver-ports/audit/index.ts
@@ -1,0 +1,1 @@
+export * from './for-auditing-externals.port';

--- a/src/lib/2.app/flows/audit/externals-audit.spec.ts
+++ b/src/lib/2.app/flows/audit/externals-audit.spec.ts
@@ -1,0 +1,207 @@
+import { createExternalsAudit } from './externals-audit';
+import { NFError } from 'lib/native-federation.error';
+import { LoggingConfig, ModeConfig } from '../../config';
+import { DrivingContract } from '../../driving-ports/driving.contract';
+import { RemoteEntry } from 'lib/1.domain';
+import { mockConfig } from 'lib/6.mocks/config.mock';
+import { mockAdapters } from 'lib/6.mocks/adapters.mock';
+import { mockRemoteEntry_MFE1 } from 'lib/6.mocks/domain/remote-entry/remote-entry.mock';
+import { mockSharedInfo } from 'lib/6.mocks/domain/remote-entry/shared-info.mock';
+import { mockExternal_A, mockExternal_B } from 'lib/6.mocks/domain/externals/external.mock';
+import { mockVersion_A, mockVersion_B } from 'lib/6.mocks/domain/externals/version.mock';
+
+describe('createExternalsAudit', () => {
+  let externalsAudit: (remoteEntry: RemoteEntry, strictVersion: boolean) => Promise<void>;
+  let config: LoggingConfig & ModeConfig;
+  let ports: Pick<DrivingContract, 'versionCheck' | 'sharedExternalsRepo' | 'scopedExternalsRepo'>;
+
+  beforeEach(() => {
+    config = mockConfig();
+    ports = mockAdapters();
+
+    externalsAudit = createExternalsAudit(config, ports);
+
+    ports.sharedExternalsRepo.getScopes = jest.fn(() => ['__GLOBAL__']);
+    ports.sharedExternalsRepo.getFromScope = jest.fn(() => ({}));
+    ports.versionCheck.isCompatible = jest.fn(() => false);
+    ports.versionCheck.compare = jest.fn(() => 0);
+  });
+
+  describe('successful audit scenarios', () => {
+    it('should resolve when all externals pass audit checks', async () => {
+      const remoteEntry = mockRemoteEntry_MFE1({
+        shared: [
+          mockSharedInfo('dep-a', {
+            singleton: false,
+            requiredVersion: '~1.0.0',
+          }),
+        ],
+      });
+
+      await expect(externalsAudit(remoteEntry, false)).resolves.toBeUndefined();
+    });
+
+    it('should resolve when no externals are shared', async () => {
+      const remoteEntry = mockRemoteEntry_MFE1({
+        shared: [],
+      });
+
+      await expect(externalsAudit(remoteEntry, true)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('audit: external could be singleton but is scoped instead', () => {
+    it('should warn when non-singleton external is compatible with shared version', async () => {
+      const remoteEntry = mockRemoteEntry_MFE1({
+        shared: [
+          mockSharedInfo('dep-a', {
+            singleton: false,
+            requiredVersion: '~2.1.0',
+          }),
+        ],
+      });
+
+      (ports.sharedExternalsRepo.getFromScope as jest.Mock).mockReturnValue({
+        'dep-a': mockExternal_A({
+          dirty: false,
+          versions: [mockVersion_A.v2_1_1({ remotes: ['team/other-mfe'], action: 'share' })],
+        }),
+      });
+      (ports.versionCheck.isCompatible as jest.Mock).mockReturnValue(true);
+
+      await expect(externalsAudit(remoteEntry, false)).resolves.toBeUndefined();
+
+      expect(config.log.warn).toHaveBeenCalledWith(
+        3,
+        "[team/mfe1][scoped][__GLOBAL__][dep-a] External is compatible with shared range '~2.1.0'. Should be 'singleton: true'"
+      );
+    });
+
+    it('should not warn when non-singleton external is not compatible', async () => {
+      const remoteEntry = mockRemoteEntry_MFE1({
+        shared: [
+          mockSharedInfo('dep-a', {
+            singleton: false,
+            requiredVersion: '~2.0.0',
+          }),
+        ],
+      });
+
+      (ports.sharedExternalsRepo.getFromScope as jest.Mock).mockReturnValue({
+        'dep-a': mockExternal_A({
+          dirty: false,
+          versions: [mockVersion_A.v2_1_1({ remotes: ['team/other-mfe'], action: 'share' })],
+        }),
+      });
+      (ports.versionCheck.isCompatible as jest.Mock).mockReturnValue(false);
+
+      await expect(externalsAudit(remoteEntry, false)).resolves.toBeUndefined();
+
+      expect(config.log.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('audit: external should be scoped but is singleton instead', () => {
+    it('should warn when scoped external is older than shared version', async () => {
+      const remoteEntry = mockRemoteEntry_MFE1({
+        shared: [],
+      });
+
+      (ports.sharedExternalsRepo.getFromScope as jest.Mock).mockReturnValue({
+        'dep-b': mockExternal_B({
+          dirty: false,
+          versions: [
+            mockVersion_B.v2_1_1({ remotes: ['team/mfe1'], action: 'scope' }),
+            mockVersion_B.v2_2_2({ remotes: ['team/other-mfe'], action: 'share' }),
+          ],
+        }),
+      });
+      (ports.versionCheck.compare as jest.Mock).mockReturnValue(-1);
+
+      await expect(externalsAudit(remoteEntry, false)).resolves.toBeUndefined();
+
+      expect(config.log.warn).toHaveBeenCalledWith(
+        3,
+        "[team/mfe1][shared][__GLOBAL__][dep-b@2.1.1] External is older than shared compatible range '~2.2.0'. Should be 'singleton: false'"
+      );
+    });
+
+    it('should warn when scoped external is newer than shared version', async () => {
+      const remoteEntry = mockRemoteEntry_MFE1({
+        shared: [],
+      });
+
+      (ports.sharedExternalsRepo.getFromScope as jest.Mock).mockReturnValue({
+        'dep-b': mockExternal_B({
+          dirty: false,
+          versions: [
+            mockVersion_B.v2_2_2({ remotes: ['team/mfe1'], action: 'scope' }),
+            mockVersion_B.v2_1_1({ remotes: ['team/other-mfe'], action: 'share' }),
+          ],
+        }),
+      });
+      (ports.versionCheck.compare as jest.Mock).mockReturnValue(1);
+
+      await expect(externalsAudit(remoteEntry, false)).resolves.toBeUndefined();
+
+      expect(config.log.warn).toHaveBeenCalledWith(
+        3,
+        "[team/mfe1][shared][__GLOBAL__][dep-b@2.2.2] External is newer than shared compatible range '~2.1.0'."
+      );
+    });
+  });
+
+  describe('strict mode error handling', () => {
+    it('should reject with NFError when audit fails in strict mode', async () => {
+      const remoteEntry = mockRemoteEntry_MFE1({
+        shared: [
+          mockSharedInfo('dep-a', {
+            singleton: false,
+            requiredVersion: '~2.1.0',
+          }),
+        ],
+      });
+
+      (ports.sharedExternalsRepo.getFromScope as jest.Mock).mockReturnValue({
+        'dep-a': mockExternal_A({
+          dirty: false,
+          versions: [mockVersion_A.v2_1_1({ remotes: ['team/other-mfe'], action: 'share' })],
+        }),
+      });
+      (ports.versionCheck.isCompatible as jest.Mock).mockReturnValue(true);
+
+      await expect(externalsAudit(remoteEntry, true)).rejects.toEqual(
+        new NFError('Failed externals audit')
+      );
+
+      expect(config.log.error).toHaveBeenCalledWith(
+        3,
+        '[team/mfe1] Not all externals are compatible.'
+      );
+    });
+
+    it('should not reject in non-strict mode even when warnings occur', async () => {
+      const remoteEntry = mockRemoteEntry_MFE1({
+        shared: [
+          mockSharedInfo('dep-a', {
+            singleton: false,
+            requiredVersion: '~2.1.0',
+          }),
+        ],
+      });
+
+      (ports.sharedExternalsRepo.getFromScope as jest.Mock).mockReturnValue({
+        'dep-a': mockExternal_A({
+          dirty: false,
+          versions: [mockVersion_A.v2_1_1({ remotes: ['team/other-mfe'], action: 'share' })],
+        }),
+      });
+      (ports.versionCheck.isCompatible as jest.Mock).mockReturnValue(true);
+
+      await expect(externalsAudit(remoteEntry, false)).resolves.toBeUndefined();
+
+      expect(config.log.warn).toHaveBeenCalled();
+      expect(config.log.error).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/lib/2.app/flows/audit/externals-audit.ts
+++ b/src/lib/2.app/flows/audit/externals-audit.ts
@@ -1,0 +1,80 @@
+import { NFError } from 'lib/native-federation.error';
+import type { LoggingConfig, ModeConfig } from '../../config';
+import type { DrivingContract } from '../../driving-ports/driving.contract';
+import type { RemoteEntry, SharedExternal, SharedVersion } from 'lib/1.domain';
+
+export function createExternalsAudit(
+  config: LoggingConfig & ModeConfig,
+  ports: Pick<DrivingContract, 'versionCheck' | 'sharedExternalsRepo' | 'scopedExternalsRepo'>
+): (remoteEntry: RemoteEntry, strictVersion: boolean) => Promise<void> {
+  return (remoteEntry, strictVersionChecking) => {
+    let success = true;
+    remoteEntry.shared
+      .filter(external => !external.singleton)
+      .forEach(external => {
+        const isValid = checkIfExternalCouldBeSingleton(external, remoteEntry);
+        if (!isValid) success = false;
+      });
+
+    const isValid = warnForScopedSingletons(remoteEntry);
+    if (!isValid) success = false;
+
+    if (!success && strictVersionChecking) {
+      config.log.error(3, `[${remoteEntry.name}] Not all externals are compatible.`);
+      return Promise.reject(new NFError(`Failed externals audit`));
+    }
+    return Promise.resolve();
+  };
+
+  function checkIfExternalCouldBeSingleton(
+    targetExternal: { packageName: string; requiredVersion: string },
+    remoteEntry: RemoteEntry
+  ) {
+    for (const shareScope of ports.sharedExternalsRepo.getScopes()) {
+      const sharedExternal =
+        ports.sharedExternalsRepo.getFromScope(shareScope)[targetExternal.packageName];
+      if (!sharedExternal) continue;
+
+      for (const version of sharedExternal.versions) {
+        if (version.action !== 'share') return true;
+
+        if (ports.versionCheck.isCompatible(version.tag, targetExternal.requiredVersion)) {
+          const msg = `[${remoteEntry.name}][scoped][${shareScope}][${targetExternal.packageName}] External is compatible with shared range '${version.remotes[0]!.requiredVersion}'. Should be 'singleton: true'`;
+          config.log.warn(3, msg);
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  function warnForScopedSingletons(remoteEntry: RemoteEntry) {
+    let success = true;
+    for (const shareScope of ports.sharedExternalsRepo.getScopes()) {
+      for (const [packageName, external] of Object.entries<SharedExternal>(
+        ports.sharedExternalsRepo.getFromScope(shareScope)
+      )) {
+        for (const version of external.versions as SharedVersion[]) {
+          if (version.action !== 'scope') continue;
+
+          if (version.remotes.some(remote => remote.name === remoteEntry.name)) {
+            const sharedVersion = external.versions.find(v => v.action === 'share');
+            const isOlder =
+              sharedVersion && ports.versionCheck.compare(version.tag, sharedVersion.tag) === -1;
+
+            let msg = `[${remoteEntry.name}][shared][${shareScope}][${packageName}@${version.tag}] External is ${
+              isOlder ? 'older' : 'newer'
+            } than shared compatible range '${sharedVersion?.remotes[0]!.requiredVersion}'.`;
+
+            if (isOlder) {
+              success = false;
+              msg += " Should be 'singleton: false'";
+            }
+            config.log.warn(3, msg);
+          }
+        }
+      }
+    }
+    return success;
+  }
+}

--- a/src/lib/2.app/flows/dynamic-init/convert-to-import-map.spec.ts
+++ b/src/lib/2.app/flows/dynamic-init/convert-to-import-map.spec.ts
@@ -1,4 +1,4 @@
-import { LoggingConfig } from '../init';
+import { LoggingConfig } from '../../config/log.contract';
 import { ForConvertingToImportMap } from 'lib/2.app/driver-ports/dynamic-init/for-converting-to-import-map';
 import { createConvertToImportMap } from './convert-to-import-map';
 import { RemoteEntry, SharedInfoActions } from 'lib/1.domain';

--- a/src/lib/2.app/flows/dynamic-init/get-remote-entry.spec.ts
+++ b/src/lib/2.app/flows/dynamic-init/get-remote-entry.spec.ts
@@ -86,15 +86,19 @@ describe('createGetRemoteEntry', () => {
     });
 
     it('should reject if fetched remote name does not match requested name on strict mode', async () => {
-      config.strict = true;
+      config.strict.strictRemoteEntry = true;
       await expect(
         getRemoteEntry(mockScopeUrl_MFE1({ file: 'remoteEntry.json' }), 'team/mfe2')
       ).rejects.toThrow('Could not fetch remoteEntry.');
 
       expect(config.log.error).toHaveBeenCalledWith(
         7,
+        "Fetched remote 'team/mfe1' does not match requested 'team/mfe2'."
+      );
+      expect(config.log.error).toHaveBeenCalledWith(
+        7,
         '[team/mfe2] Could not fetch remoteEntry from http://my.service/mfe1/remoteEntry.json.',
-        new NFError("Fetched remote 'team/mfe1' does not match requested 'team/mfe2'.")
+        new NFError('Could not fetch remote entry')
       );
     });
   });

--- a/src/lib/2.app/flows/dynamic-init/get-remote-entry.ts
+++ b/src/lib/2.app/flows/dynamic-init/get-remote-entry.ts
@@ -27,9 +27,12 @@ export function createGetRemoteEntry(
         `[${remoteEntry.name}] Fetched from '${remoteEntry.url}', exposing: ${JSON.stringify(remoteEntry.exposes)}`
       );
       if (!!remoteName && remoteEntry.name !== remoteName) {
-        const errorMessage = `Fetched remote '${remoteEntry.name}' does not match requested '${remoteName}'.`;
-        if (config.strict) throw new NFError(errorMessage);
-        config.log.warn(7, errorMessage + ' Omitting expected name.');
+        const errorMsg = `Fetched remote '${remoteEntry.name}' does not match requested '${remoteName}'.`;
+        if (config.strict.strictRemoteEntry) {
+          config.log.error(7, errorMsg);
+          throw new NFError('Could not fetch remote entry');
+        }
+        config.log.warn(7, errorMsg + ' Omitting expected name.');
       }
 
       if (ports.remoteInfoRepo.contains(remoteEntry.name)) {

--- a/src/lib/2.app/flows/dynamic-init/update-cache.global.spec.ts
+++ b/src/lib/2.app/flows/dynamic-init/update-cache.global.spec.ts
@@ -170,7 +170,7 @@ describe('createProcessDynamicRemoteEntry - scoped', () => {
 
   it('should add and scope shared external to list with incompatible version and strictVersion', async () => {
     adapters.versionCheck.isCompatible = jest.fn(() => false);
-    config.strict = false;
+    config.strict.strictExternalCompatibility = false;
     adapters.sharedExternalsRepo.tryGet = jest.fn(
       (): Optional<SharedExternal> =>
         Optional.of(
@@ -215,7 +215,7 @@ describe('createProcessDynamicRemoteEntry - scoped', () => {
 
   it('should throw an error when shared external with incompatible version and strictVersion and strict', async () => {
     adapters.versionCheck.isCompatible = jest.fn(() => false);
-    config.strict = true;
+    config.strict.strictExternalCompatibility = true;
     adapters.sharedExternalsRepo.tryGet = jest.fn(
       (): Optional<SharedExternal> =>
         Optional.of(
@@ -278,7 +278,7 @@ describe('createProcessDynamicRemoteEntry - scoped', () => {
 
   it('should warn users if the requiredVersions differ and strictVersion', async () => {
     adapters.versionCheck.isCompatible = jest.fn(() => true);
-    config.strict = false;
+    config.strict.strictExternalCompatibility = false;
     adapters.sharedExternalsRepo.tryGet = jest.fn(
       (): Optional<SharedExternal> =>
         Optional.of(
@@ -329,7 +329,7 @@ describe('createProcessDynamicRemoteEntry - scoped', () => {
 
   it('should throw an error if the requiredVersions differs if strictVersion and in strict mode', async () => {
     adapters.versionCheck.isCompatible = jest.fn(() => true);
-    config.strict = true;
+    config.strict.strictExternalCompatibility = true;
     adapters.sharedExternalsRepo.tryGet = jest.fn(
       (): Optional<SharedExternal> =>
         Optional.of(

--- a/src/lib/2.app/flows/dynamic-init/update-cache.spec.ts
+++ b/src/lib/2.app/flows/dynamic-init/update-cache.spec.ts
@@ -110,7 +110,7 @@ describe('createProcessDynamicRemoteEntry', () => {
 
   describe('handling a missing version property', () => {
     it('should handle invalid versions in strict mode', async () => {
-      config.strict = true;
+      config.strict.strictExternalVersion = true;
       adapters.versionCheck.isValidSemver = jest.fn(() => false);
 
       const remoteEntry = mockRemoteEntry_MFE1({
@@ -129,7 +129,7 @@ describe('createProcessDynamicRemoteEntry', () => {
     });
 
     it('should handle undefined versions in strict mode', async () => {
-      config.strict = true;
+      config.strict.strictExternalVersion = true;
       adapters.versionCheck.isValidSemver = jest.fn(() => false);
 
       const remoteEntry = mockRemoteEntry_MFE1({

--- a/src/lib/2.app/flows/init/commit-changes.spec.ts
+++ b/src/lib/2.app/flows/init/commit-changes.spec.ts
@@ -1,7 +1,7 @@
+import { LoggingConfig } from 'lib/options.index';
 import { ForCommittingChanges } from '../../driver-ports/init/for-committing-changes.port';
 import { DrivingContract } from '../../driving-ports/driving.contract';
 import { createCommitChanges } from './commit-changes';
-import { LoggingConfig } from '.';
 import { mockAdapters } from 'lib/6.mocks/adapters.mock';
 import { mockConfig } from 'lib/6.mocks/config.mock';
 

--- a/src/lib/2.app/flows/init/determine-shared-externals.spec.ts
+++ b/src/lib/2.app/flows/init/determine-shared-externals.spec.ts
@@ -59,7 +59,7 @@ describe('createDetermineSharedExternals', () => {
 
   describe('handle version incompatibilities', () => {
     it('should set "skip" if incompatible, strictVersion is false and in non-strict mode', async () => {
-      config.strict = false;
+      config.strict.strictExternalCompatibility = false;
 
       adapters.sharedExternalsRepo.getFromScope = jest.fn(() => ({
         'dep-b': mockExternal_B({
@@ -93,7 +93,7 @@ describe('createDetermineSharedExternals', () => {
     });
 
     it('should set "scoped" if incompatible, strictVersion is true and in non-strict mode', async () => {
-      config.strict = false;
+      config.strict.strictExternalCompatibility = false;
 
       adapters.sharedExternalsRepo.getFromScope = jest.fn(() => ({
         'dep-b': mockExternal_B({
@@ -127,7 +127,7 @@ describe('createDetermineSharedExternals', () => {
     });
 
     it('should throw error if incompatible, strictVersion is true and in strict mode', async () => {
-      config.strict = true;
+      config.strict.strictExternalCompatibility = true;
 
       adapters.sharedExternalsRepo.getFromScope = jest.fn(() => ({
         'dep-b': mockExternal_B({

--- a/src/lib/2.app/flows/init/determine-shared-externals.ts
+++ b/src/lib/2.app/flows/init/determine-shared-externals.ts
@@ -103,7 +103,7 @@ export function createDetermineSharedExternals(
         return;
       }
 
-      if (config.strict && v.remotes[0]!.strictVersion) {
+      if (config.strict.strictExternalCompatibility && v.remotes[0]!.strictVersion) {
         config.log.error(
           3,
           `[${v.remotes[0]!.name}][${externalName}@${v.tag}] Is not compatible with requiredRange '${sharedVersion!.remotes[0]?.requiredVersion}' from remote '${sharedVersion!.remotes[0]!.name}'.`

--- a/src/lib/2.app/flows/init/generate-import-map.shared.spec.ts
+++ b/src/lib/2.app/flows/init/generate-import-map.shared.spec.ts
@@ -168,7 +168,7 @@ describe('createGenerateImportMap (shared-externals)', () => {
   });
 
   it('should warn the user about 2 shared versions and choose the most recent one if in non-strict mode.', async () => {
-    config.strict = false;
+    config.strict.strictImportMap = false;
 
     adapters.sharedExternalsRepo.getFromScope = jest.fn(() => ({
       'dep-a': mockExternal_A({
@@ -193,7 +193,7 @@ describe('createGenerateImportMap (shared-externals)', () => {
   });
 
   it('should throw error if 2 shared versions and in strict mode.', async () => {
-    config.strict = true;
+    config.strict.strictImportMap = true;
 
     adapters.sharedExternalsRepo.getFromScope = jest.fn(() => ({
       'dep-a': mockExternal_A({

--- a/src/lib/2.app/flows/init/generate-import-map.sharescope.spec.ts
+++ b/src/lib/2.app/flows/init/generate-import-map.sharescope.spec.ts
@@ -178,7 +178,7 @@ describe('createGenerateImportMap (shareScope-externals)', () => {
   });
 
   it('should throw an error if no override version is available and strict.', async () => {
-    config.strict = true;
+    config.strict.strictImportMap = true;
     adapters.sharedExternalsRepo.getFromScope = jest.fn((scope?: string): shareScope => {
       return !scope || scope === GLOBAL_SCOPE
         ? {}
@@ -276,7 +276,7 @@ describe('createGenerateImportMap (shareScope-externals)', () => {
   });
 
   it('should warn the user about 2 shared versions and choose the most recent one if in non-strict mode.', async () => {
-    config.strict = false;
+    config.strict.strictImportMap = false;
 
     adapters.sharedExternalsRepo.getFromScope = jest.fn((scope?: string): shareScope => {
       return !scope || scope === GLOBAL_SCOPE
@@ -316,7 +316,7 @@ describe('createGenerateImportMap (shareScope-externals)', () => {
   });
 
   it('should throw error if 2 shared versions and in strict mode when attempting an override.', async () => {
-    config.strict = true;
+    config.strict.strictImportMap = true;
     adapters.sharedExternalsRepo.getFromScope = jest.fn((scope?: string): shareScope => {
       return !scope || scope === GLOBAL_SCOPE
         ? {}
@@ -340,7 +340,7 @@ describe('createGenerateImportMap (shareScope-externals)', () => {
   });
 
   it('should warn the user about 0 shared versions and scope all if in non-strict mode.', async () => {
-    config.strict = false;
+    config.strict.strictImportMap = false;
 
     adapters.sharedExternalsRepo.getFromScope = jest.fn((scope?: string): shareScope => {
       return !scope || scope === GLOBAL_SCOPE
@@ -370,7 +370,7 @@ describe('createGenerateImportMap (shareScope-externals)', () => {
   });
 
   it('should throw error if 0 shared versions and in strict mode.', async () => {
-    config.strict = true;
+    config.strict.strictImportMap = true;
 
     adapters.sharedExternalsRepo.getFromScope = jest.fn((scope?: string): shareScope => {
       return !scope || scope === GLOBAL_SCOPE

--- a/src/lib/2.app/flows/init/generate-import-map.ts
+++ b/src/lib/2.app/flows/init/generate-import-map.ts
@@ -139,7 +139,7 @@ export function createGenerateImportMap(
     }
 
     if (sharedVersions.length < 1) {
-      if (config.strict) {
+      if (config.strict.strictImportMap) {
         config.log.error(4, `[${shareScope}][${externalName}] shareScope has no override version.`);
         throw new NFError('Could not create ImportMap.');
       }
@@ -153,7 +153,7 @@ export function createGenerateImportMap(
   }
 
   function handleMultipleSharedVersions(scopedExternalName: string): void {
-    if (config.strict) {
+    if (config.strict.strictImportMap) {
       config.log.error(
         4,
         `[${scopedExternalName}] ShareScope external has multiple shared versions.`
@@ -202,7 +202,7 @@ export function createGenerateImportMap(
   }
 
   function handleDuplicateGlobalExternal(externalName: string): void {
-    if (config.strict) {
+    if (config.strict.strictImportMap) {
       config.log.error(4, `[${externalName}] Shared external has multiple shared versions.`);
       throw new NFError('Could not create ImportMap.');
     }

--- a/src/lib/2.app/flows/init/get-remote-entries.spec.ts
+++ b/src/lib/2.app/flows/init/get-remote-entries.spec.ts
@@ -256,7 +256,7 @@ describe('createGetRemoteEntries', () => {
 
   describe('error handling', () => {
     it('should handle failed remote fetch in non-strict mode', async () => {
-      config.strict = false;
+      config.strict.strictRemoteEntry = false;
       adapters.remoteEntryProvider.provide = jest.fn(url => {
         if (url === `${mockScopeUrl_MFE1()}remoteEntry.json`) {
           return Promise.resolve(mockRemoteEntry_MFE1());
@@ -278,7 +278,7 @@ describe('createGetRemoteEntries', () => {
     });
 
     it('should throw error when remote fetch fails in strict mode', async () => {
-      config.strict = true;
+      config.strict.strictRemoteEntry = true;
 
       adapters.remoteEntryProvider.provide = jest.fn(url => {
         if (url === `${mockScopeUrl_MFE2()}remoteEntry.json`) {
@@ -328,7 +328,7 @@ describe('createGetRemoteEntries', () => {
     });
 
     it('should throw an error when remote entry name does not match requested name on strict mode', () => {
-      config.strict = true;
+      config.strict.strictRemoteEntry = true;
       const manifestWithBadEntryName = {
         'bad-mfe-name': `${mockScopeUrl_MFE1()}remoteEntry.json`,
       };

--- a/src/lib/2.app/flows/init/get-remote-entries.ts
+++ b/src/lib/2.app/flows/init/get-remote-entries.ts
@@ -87,7 +87,7 @@ export function createGetRemoteEntries(
 
       return prepareRemoteEntry(remoteEntry, remoteName, isOverride);
     } catch (error) {
-      if (config.strict) {
+      if (config.strict.strictRemoteEntry) {
         config.log.error(1, `Could not fetch remote '${remoteName}'.`, error);
         return Promise.reject(new NFError(`Could not fetch remote '${remoteName}'`));
       }
@@ -111,7 +111,7 @@ export function createGetRemoteEntries(
 
     if (remoteEntry.name !== expectedRemoteName) {
       const errorDetails = `Fetched remote '${remoteEntry.name}' does not match requested '${expectedRemoteName}'.`;
-      if (config.strict) {
+      if (config.strict.strictRemoteEntry) {
         throw new NFError(errorDetails);
       }
       config.log.warn(1, `${errorDetails} Omitting expected name.`);

--- a/src/lib/2.app/flows/init/index.ts
+++ b/src/lib/2.app/flows/init/index.ts
@@ -1,1 +1,0 @@
-export * from '../../config';

--- a/src/lib/2.app/flows/init/process-remote-entries.global.spec.ts
+++ b/src/lib/2.app/flows/init/process-remote-entries.global.spec.ts
@@ -234,8 +234,8 @@ describe('createProcessRemoteEntries - global', () => {
         "[team/mfe2][dep-a@2.1.2] Required version-range '~1.2.2' does not match cached version-range '~1.2.1'"
       );
     });
-    it('should not throw an error if the requiredVersions differs if strictVersion and in strict mode', async () => {
-      config.strict = true;
+    it('should throw an error if the requiredVersions differs if strictVersion and in strict mode', async () => {
+      config.strict.strictExternalCompatibility = true;
       adapters.sharedExternalsRepo.tryGet = jest.fn(
         (): Optional<SharedExternal> =>
           Optional.of(
@@ -258,27 +258,11 @@ describe('createProcessRemoteEntries - global', () => {
         }),
       ];
 
-      await processRemoteEntries(remoteEntries);
-
-      expect(adapters.sharedExternalsRepo.addOrUpdate).toHaveBeenCalledTimes(1);
-      expect(adapters.sharedExternalsRepo.addOrUpdate).toHaveBeenCalledWith(
-        'dep-a',
-        mockExternal.shared(
-          [
-            mockVersion_A.v2_1_2({
-              remotes: {
-                'team/mfe1': { requiredVersion: '~1.2.1' },
-                'team/mfe2': { requiredVersion: '~1.2.2' },
-              },
-              action: 'skip',
-            }),
-          ],
-          { dirty: false }
-        ),
-        undefined
+      await expect(processRemoteEntries(remoteEntries)).rejects.toThrow(
+        `Could not process remote 'team/mfe2'`
       );
 
-      expect(config.log.warn).toHaveBeenCalledWith(
+      expect(config.log.error).toHaveBeenCalledWith(
         2,
         "[team/mfe2][dep-a@2.1.2] Required version-range '~1.2.2' does not match cached version-range '~1.2.1'"
       );

--- a/src/lib/2.app/flows/init/process-remote-entries.spec.ts
+++ b/src/lib/2.app/flows/init/process-remote-entries.spec.ts
@@ -80,7 +80,7 @@ describe('createProcessRemoteEntries', () => {
 
   describe('handling a missing version property', () => {
     it('should handle invalid versions in strict mode', async () => {
-      config.strict = true;
+      config.strict.strictExternalVersion = true;
       adapters.versionCheck.isValidSemver = jest.fn(() => false);
 
       const remoteEntries = [
@@ -100,7 +100,7 @@ describe('createProcessRemoteEntries', () => {
     });
 
     it('should handle undefined versions in strict mode', async () => {
-      config.strict = true;
+      config.strict.strictExternalVersion = true;
       adapters.versionCheck.isValidSemver = jest.fn(() => false);
 
       const remoteEntries = [

--- a/src/lib/4.config/default.config.spec.ts
+++ b/src/lib/4.config/default.config.spec.ts
@@ -44,7 +44,12 @@ describe('DefaultConfig', () => {
       const actual = createModeConfig({});
 
       expect(actual).toEqual({
-        strict: false,
+        strict: {
+          strictRemoteEntry: false,
+          strictExternalCompatibility: false,
+          strictExternalVersion: false,
+          strictImportMap: false,
+        },
         profile: {
           latestSharedExternal: false,
           overrideCachedRemotes: 'init-only',

--- a/src/lib/4.config/mode/mode.config.spec.ts
+++ b/src/lib/4.config/mode/mode.config.spec.ts
@@ -27,6 +27,11 @@ describe('config.mode', () => {
 
   it('should set strict: false by default', () => {
     const config = createModeConfig({});
-    expect(config.strict).toBe(false);
+    expect(config.strict).toEqual({
+      strictRemoteEntry: false,
+      strictExternalCompatibility: false,
+      strictExternalVersion: false,
+      strictImportMap: false,
+    });
   });
 });

--- a/src/lib/4.config/mode/mode.config.ts
+++ b/src/lib/4.config/mode/mode.config.ts
@@ -1,7 +1,24 @@
 import type { ModeConfig, ModeOptions } from 'lib/2.app/config/mode.contract';
 import { defaultProfile } from './default.profile';
 
-export const createModeConfig = (override: ModeOptions): ModeConfig => ({
-  strict: override.strict ?? false,
-  profile: override.profile ?? defaultProfile,
-});
+export const createModeConfig = (override: ModeOptions): ModeConfig => {
+  const strictnessConfig =
+    typeof override.strict === 'boolean'
+      ? {
+          strictRemoteEntry: override.strict,
+          strictExternalCompatibility: override.strict,
+          strictExternalVersion: override.strict,
+          strictImportMap: override.strict,
+        }
+      : {
+          strictRemoteEntry: override.strict?.strictRemoteEntry ?? false,
+          strictExternalCompatibility: override.strict?.strictExternalCompatibility ?? false,
+          strictExternalVersion: override.strict?.strictExternalVersion ?? false,
+          strictImportMap: override.strict?.strictImportMap ?? false,
+        };
+
+  return {
+    strict: strictnessConfig,
+    profile: { ...defaultProfile, ...(override.profile ?? {}) },
+  };
+};

--- a/src/lib/6.mocks/config.mock.ts
+++ b/src/lib/6.mocks/config.mock.ts
@@ -17,7 +17,12 @@ export const mockConfig = (): ConfigContract => ({
   // hostConfig
   hostRemoteEntry: false,
   // ModeConfig
-  strict: false,
+  strict: {
+    strictRemoteEntry: false,
+    strictExternalCompatibility: false,
+    strictExternalVersion: false,
+    strictImportMap: false,
+  },
   profile: {
     latestSharedExternal: false,
     overrideCachedRemotes: 'always',

--- a/src/lib/audit.index.ts
+++ b/src/lib/audit.index.ts
@@ -1,0 +1,3 @@
+export * from './2.app/driver-ports/dynamic-init';
+
+export * from './2.app/flows/audit/externals-audit';

--- a/src/lib/init-federation.ts
+++ b/src/lib/init-federation.ts
@@ -62,7 +62,7 @@ const initFederation = (
           .then(entry => entry.map(processDynamicRemoteEntry).orElse(Promise.resolve()))
           .catch(e => {
             stateDump(`[dynamic-init][${remoteName ?? remoteEntryUrl}] STATE DUMP`);
-            if (config.strict) return Promise.reject(e);
+            if (config.strict.strictRemoteEntry) return Promise.reject(e);
             else console.warn('Failed to initialize remote entry, continuing anyway.');
             return Promise.resolve();
           })


### PR DESCRIPTION
closes #90.

Can be used in a github action to check the mfe compatibility:

**Usage:**
```javascript
import { setFailed, getInput } from "@actions/core";
import { CREATE_NF_APP } from "vanilla-native-federation";
import { consoleLogger } from "vanilla-native-federation/options";
import { createExternalsAudit } from "vanilla-native-federation/audit";

async function main() {
  let importMap = null;
  try {
    // Get the remoteEntry from your build 
    const remoteEntryPath = "http://localhost:3000/browser/remoteEntry.json";
    const remoteName = "@team/mfe1";

    console.log("- === FETCHING MANIFEST ===");

    const manifest = await fetchManifestAndPatch("http://localhost:4000/manifest.json", remoteName, remoteEntryPath);

    const { init, config, adapters } = CREATE_NF_APP({
      strict: false,
      logger: consoleLogger,
      logLevel: "debug",
    });

    console.log("===== FETCHING REMOTE ENTRIES =====");

    const remoteEntries = await init.getRemoteEntries(manifest);

    console.log("===== PROCESSING REMOTE ENTRIES =====");

    const processedRemoteEntries = await init.processRemoteEntries(remoteEntries);

    /**
     * Find your target remoteEntry
     */
    const targetRemoteEntry = processedRemoteEntries.find((f) => f.name === remoteName);
    if (!targetRemoteEntry) {
      throw new Error(`Local remote entry '${remoteName}' not found`);
    }

    console.log("===== DETERMINING SHARED EXTERNALS =====");

    await init.determineSharedExternals();


    /**
     * New audit step!
     */
    const checkForPotentiallySharedExternals = createExternalsAudit(config, adapters);

    const strictVersionChecking = true; // fail if bad version
    await checkForPotentiallySharedExternals(targetRemoteEntry, strictVersionChecking);
    
    console.log("===== GENERATING IMPORT MAP =====");
    
    importMap = await init.generateImportMap();

    console.log("✅ Micro frontend is compatible with current manifest!");

  } catch (error: any) {
    console.log("===== DEBUG INFO DUMP =====");

    console.log("importMap:", importMap);

    setFailed(error);
  }
}

async function fetchManifestAndPatch(host: string, remoteName: string, remoteEntryPath: string) {
  console.log(`- Fetching manifest from '${host}'.`);

  const manifest = await fetch(host).then((res) => res.json());
  manifest[remoteName] = remoteEntryPath;
  console.log("Manifest:", manifest);
  return manifest;
}

main();
```